### PR TITLE
Exclude SDK node_modules and demo GIFs from VSIX package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -25,3 +25,7 @@ out/**/*.map
 
 # SDK source dependency is bundled into out/sdk/piSdkBundle.mjs
 node_modules/@earendil-works/pi-coding-agent/**
+out/sdk/node_modules/**
+
+# Documentation/demo captures are not needed at runtime
+resources/*.gif


### PR DESCRIPTION
## Background

Sorry for the confusion — PR #14 was closed because it was opened against the wrong commit. Its title/description belonged to a different change (`Add open navigation for edit diff cards`), while the actual diff it carried was this VSIX slimming change. This new PR replaces it with the correct title and description.

## What this change does

Adds two entries to `.vscodeignore` to shrink the packaged VSIX:

```diff
 # SDK source dependency is bundled into out/sdk/piSdkBundle.mjs
 node_modules/@earendil-works/pi-coding-agent/**
+out/sdk/node_modules/**
+
+# Documentation/demo captures are not needed at runtime
+resources/*.gif
```

### `out/sdk/node_modules/**`

When the Pi SDK is bundled via esbuild (`scripts/build-sdk-bundle.js`), the build also emits `out/sdk/node_modules/` (~117 MB on disk). The runtime only needs the bundled `out/sdk/piSdkBundle.mjs`, so these nested `node_modules` are dead weight in the VSIX.

### `resources/*.gif`

Excludes the three demo/capture GIFs under `resources/` (~8.6 MB total: `doom-twice.gif`, `tauren_capture.gif`, `custom-ui.gif`). These are only used in documentation/README, not at runtime.

## Impact

| Item | Excluded size |
|---|---|
| `out/sdk/node_modules/` | ~117 MB |
| `resources/*.gif` | ~8.6 MB |

The packaged VSIX drops to **~8.3 MB**. Without these rules it would balloon to **30 MB+**.

No runtime behavior change — only packaging output is affected.