### PR TITLE
feat: show Pi prompts inline in transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Rendered Pi extension choices, confirmations, and text questions as inline Transcript Entries instead of native VS Code prompts.
+
 ## [1.9.1] - 2026-07-11
 
 ### Fixed

--- a/resources/webview/chat.js
+++ b/resources/webview/chat.js
@@ -4341,6 +4341,193 @@ ${image.mimeType}, ${formatBytes(image.sizeBytes)}`;
     return value.type === "extensionEditorHide" && typeof value.id === "string" && value.id.length > 0;
   }
 
+  // src/webview/extensionPrompt.ts
+  var ExtensionPromptController = class {
+    constructor(options) {
+      this.options = options;
+    }
+    options;
+    activeId;
+    handleHostMessage(message) {
+      if (!isExtensionPromptHostMessage(message)) {
+        return false;
+      }
+      if (message.type === "extensionPromptShow") {
+        this.show(message);
+        return true;
+      }
+      if (!this.activeId || message.id === this.activeId) {
+        this.hide();
+      }
+      return true;
+    }
+    handleGlobalKeydown(event) {
+      if (!this.isActive() || event.key !== "Escape") {
+        return false;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      this.cancel();
+      return true;
+    }
+    isActive() {
+      return Boolean(this.activeId) && !this.options.element.hidden;
+    }
+    show(message) {
+      this.activeId = message.id;
+      const header = document.createElement("header");
+      header.className = "extension-prompt__header";
+      const headingGroup = document.createElement("div");
+      headingGroup.className = "extension-prompt__heading-group";
+      const eyebrow = document.createElement("div");
+      eyebrow.className = "extension-prompt__eyebrow";
+      eyebrow.textContent = "Pi needs your input";
+      const title = document.createElement("h3");
+      title.className = "extension-prompt__title";
+      title.textContent = message.title || "Choose a response";
+      headingGroup.append(eyebrow, title);
+      const close = document.createElement("button");
+      close.type = "button";
+      close.className = "extension-prompt__close";
+      close.setAttribute("aria-label", "Cancel Pi prompt");
+      close.textContent = "\xD7";
+      close.addEventListener("click", () => this.cancel());
+      header.append(headingGroup, close);
+      const body = document.createElement("div");
+      body.className = "extension-prompt__body";
+      if (message.message) {
+        const detail = document.createElement("p");
+        detail.className = "extension-prompt__message";
+        detail.textContent = message.message;
+        body.append(detail);
+      }
+      if (message.kind === "select") {
+        body.append(this.createChoiceList(message.id, message.options ?? []));
+      } else if (message.kind === "confirm") {
+        body.append(this.createConfirmActions(message.id));
+      } else {
+        body.append(this.createInputForm(message.id, message.placeholder));
+      }
+      this.options.element.replaceChildren(header, body);
+      this.options.element.hidden = false;
+      this.options.element.inert = false;
+      this.options.onShow();
+      requestAnimationFrame(() => {
+        this.options.element.querySelector("button:not(.extension-prompt__close), input")?.focus({ preventScroll: true });
+      });
+    }
+    createChoiceList(id, choices) {
+      const list = document.createElement("div");
+      list.className = "extension-prompt__choices";
+      list.setAttribute("role", "list");
+      for (const choice of choices) {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "extension-prompt__choice";
+        button.textContent = choice;
+        button.addEventListener("click", () => this.answer(id, choice));
+        button.addEventListener("keydown", (event) => this.moveChoiceFocus(event));
+        const item = document.createElement("div");
+        item.setAttribute("role", "listitem");
+        item.append(button);
+        list.append(item);
+      }
+      if (choices.length === 0) {
+        const empty = document.createElement("p");
+        empty.className = "extension-prompt__message";
+        empty.textContent = "No choices are available.";
+        list.append(empty);
+      }
+      return list;
+    }
+    createConfirmActions(id) {
+      const actions = document.createElement("div");
+      actions.className = "extension-prompt__actions";
+      const no = this.createActionButton("No", false, () => this.answer(id, false));
+      const yes = this.createActionButton("Yes", true, () => this.answer(id, true));
+      actions.append(no, yes);
+      return actions;
+    }
+    createInputForm(id, placeholder) {
+      const form2 = document.createElement("form");
+      form2.className = "extension-prompt__input-form";
+      const input = document.createElement("input");
+      input.className = "extension-prompt__input";
+      input.type = "text";
+      input.placeholder = placeholder ?? "";
+      input.setAttribute("aria-label", placeholder || "Response");
+      const actions = document.createElement("div");
+      actions.className = "extension-prompt__actions";
+      const cancel = this.createActionButton("Cancel", false, () => this.cancel());
+      const submit = this.createActionButton("Submit", true);
+      submit.type = "submit";
+      actions.append(cancel, submit);
+      form2.append(input, actions);
+      form2.addEventListener("submit", (event) => {
+        event.preventDefault();
+        this.answer(id, input.value);
+      });
+      return form2;
+    }
+    createActionButton(label, primary, onClick) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `extension-prompt__button${primary ? " extension-prompt__button--primary" : ""}`;
+      button.textContent = label;
+      if (onClick) {
+        button.addEventListener("click", onClick);
+      }
+      return button;
+    }
+    moveChoiceFocus(event) {
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") {
+        return;
+      }
+      const buttons = Array.from(this.options.element.querySelectorAll(".extension-prompt__choice"));
+      const currentIndex = buttons.indexOf(event.currentTarget);
+      if (currentIndex < 0 || buttons.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      const delta = event.key === "ArrowDown" ? 1 : -1;
+      buttons[(currentIndex + delta + buttons.length) % buttons.length]?.focus();
+    }
+    answer(id, value) {
+      if (this.activeId !== id) {
+        return;
+      }
+      this.hide();
+      this.options.vscode.postMessage({ type: "extensionPromptAnswer", id, value });
+    }
+    cancel() {
+      if (!this.activeId) {
+        return;
+      }
+      const id = this.activeId;
+      this.hide();
+      this.options.vscode.postMessage({ type: "extensionPromptCancel", id });
+    }
+    hide() {
+      this.activeId = void 0;
+      this.options.element.hidden = true;
+      this.options.element.inert = true;
+      this.options.element.replaceChildren();
+    }
+  };
+  function isExtensionPromptHostMessage(message) {
+    if (!message || typeof message !== "object") {
+      return false;
+    }
+    const value = message;
+    if (value.type === "extensionPromptHide") {
+      return typeof value.id === "string" && value.id.length > 0;
+    }
+    if (value.type !== "extensionPromptShow" || typeof value.id !== "string" || !value.id || value.kind !== "select" && value.kind !== "confirm" && value.kind !== "input" || typeof value.title !== "string") {
+      return false;
+    }
+    return (value.message === void 0 || typeof value.message === "string") && (value.placeholder === void 0 || typeof value.placeholder === "string") && (value.options === void 0 || Array.isArray(value.options) && value.options.every((option) => typeof option === "string"));
+  }
+
   // src/shared/agentRuntimeLabels.ts
   function getAgentRuntimeLabel(backend) {
     return backend === "kward" ? "Kward" : "Pi engine";
@@ -10620,7 +10807,13 @@ ${after}`;
   var busyStatusTextElement = document.createElement("span");
   busyStatusElement.append(busyStatusSpinnerElement, busyStatusTextElement);
   messagesContentElement.replaceChildren(...Array.from(messagesElement.childNodes));
-  messagesElement.append(messagesContentElement, busyStatusElement);
+  var extensionPromptElement = document.createElement("article");
+  extensionPromptElement.className = "extension-prompt";
+  extensionPromptElement.hidden = true;
+  extensionPromptElement.inert = true;
+  extensionPromptElement.setAttribute("aria-live", "polite");
+  extensionPromptElement.setAttribute("aria-label", "Pi extension prompt");
+  messagesElement.append(messagesContentElement, busyStatusElement, extensionPromptElement);
   var kwardQuestionElement = document.createElement("section");
   kwardQuestionElement.className = "kward-question";
   kwardQuestionElement.hidden = true;
@@ -10674,6 +10867,11 @@ ${after}`;
     messagesContentElement,
     busyStatusElement,
     busyStatusTextElement
+  });
+  var extensionPromptController = new ExtensionPromptController({
+    vscode,
+    element: extensionPromptElement,
+    onShow: () => messagesController.scheduleMessagesToBottom()
   });
   transcriptSearchController = new TranscriptSearchController({
     messagesElement,
@@ -10747,6 +10945,9 @@ ${after}`;
   messagesElement.addEventListener("click", (event) => messagesController.handleMessageClick(event));
   messagesElement.addEventListener("scroll", () => messagesController.handleMessagesScroll());
   window.addEventListener("message", (event) => {
+    if (extensionPromptController.handleHostMessage(event.data)) {
+      return;
+    }
     if (extensionEditorDialogController.handleHostMessage(event.data)) {
       return;
     }
@@ -10885,6 +11086,9 @@ ${after}`;
     handleHelpWindowClick(target);
   });
   window.addEventListener("keydown", (event) => {
+    if (extensionPromptController.handleGlobalKeydown(event)) {
+      return;
+    }
     if (extensionEditorDialogController.handleGlobalKeydown(event)) {
       return;
     }
@@ -11912,13 +12116,16 @@ ${after}`;
       return;
     }
     requestAnimationFrame(() => {
-      if (state.lane === "chat" && !customUiController.isActive()) {
+      if (state.lane === "chat" && !customUiController.isActive() && !extensionPromptController.isActive()) {
         textarea.focus({ preventScroll: true });
       }
     });
   }
   function focusPromptInput() {
     requestAnimationFrame(() => {
+      if (extensionPromptController.isActive()) {
+        return;
+      }
       if (customUiController.focusInput()) {
         return;
       }

--- a/src/extensionUi/types.ts
+++ b/src/extensionUi/types.ts
@@ -1,4 +1,4 @@
-import type { ExtensionUIContext, ExtensionWidgetOptions, TerminalInputHandler } from '@earendil-works/pi-coding-agent';
+import type { ExtensionUIContext, ExtensionUIDialogOptions, ExtensionWidgetOptions, TerminalInputHandler } from '@earendil-works/pi-coding-agent';
 
 export type MaybePromise<T> = T | PromiseLike<T>;
 
@@ -24,11 +24,25 @@ export type ExtensionEditorHostMessage =
   | { type: 'extensionEditorShow'; id: string; title: string; prefill: string }
   | { type: 'extensionEditorHide'; id: string };
 
+export type ExtensionPromptKind = 'select' | 'confirm' | 'input';
+
+export type ExtensionPromptHostMessage =
+  | {
+    type: 'extensionPromptShow';
+    id: string;
+    kind: ExtensionPromptKind;
+    title: string;
+    message?: string;
+    placeholder?: string;
+    options?: string[];
+  }
+  | { type: 'extensionPromptHide'; id: string };
+
 export type ExtensionUi = {
   notify(message: string, notifyType: string): void;
-  select(title: string, options: string[]): MaybePromise<string | undefined>;
-  confirm(title: string, message: string | undefined): MaybePromise<boolean | undefined>;
-  input(title: string, placeholder: string | undefined): MaybePromise<string | undefined>;
+  select(title: string, options: string[], dialogOptions?: ExtensionUIDialogOptions): MaybePromise<string | undefined>;
+  confirm(title: string, message: string | undefined, dialogOptions?: ExtensionUIDialogOptions): MaybePromise<boolean | undefined>;
+  input(title: string, placeholder: string | undefined, dialogOptions?: ExtensionUIDialogOptions): MaybePromise<string | undefined>;
   editor?(title: string, prefill: string | undefined): MaybePromise<string | undefined>;
   custom?<T>(factory: ExtensionCustomUiFactory<T>, options?: ExtensionCustomUiOptions): MaybePromise<T | undefined>;
   setStatus?(key: string, text: string | undefined): void;

--- a/src/sdk/extensionUiBridge.ts
+++ b/src/sdk/extensionUiBridge.ts
@@ -12,12 +12,12 @@ export function createSdkExtensionUiContext(ui?: ExtensionUi, options: SdkExtens
   const resolvedUi = ui ?? createCancellingExtensionUi(() => undefined);
 
   return {
-    select: (title, options, opts) => withDialogFallback(opts, undefined, () => resolvedUi.select(title, options)),
+    select: (title, options, opts) => withDialogFallback(opts, undefined, () => resolvedUi.select(title, options, opts)),
     confirm: async (title, message, opts) => {
-      const confirmed = await withDialogFallback(opts, false, () => resolvedUi.confirm(title, message));
+      const confirmed = await withDialogFallback(opts, false, () => resolvedUi.confirm(title, message, opts));
       return confirmed === true;
     },
-    input: (title, placeholder, opts) => withDialogFallback(opts, undefined, () => resolvedUi.input(title, placeholder)),
+    input: (title, placeholder, opts) => withDialogFallback(opts, undefined, () => resolvedUi.input(title, placeholder, opts)),
     notify(message, type = 'info') {
       resolvedUi.notify(message, type);
     },

--- a/src/sessions/taurenSessionManager.ts
+++ b/src/sessions/taurenSessionManager.ts
@@ -2,8 +2,13 @@ import { TaurenChatController, type PiPromptImageAttachment } from '../taurenCha
 import { ExtensionCustomUiHost, type CustomUiHostMessage } from '../extensionUi/customUiHost';
 import { ExtensionFooterHost } from '../extensionUi/extensionFooterHost';
 import { ExtensionWidgetHost } from '../extensionUi/extensionWidgetHost';
-import type { TerminalInputHandler } from '@earendil-works/pi-coding-agent';
-import type { ExtensionEditorHostMessage, ExtensionUi } from '../extensionUi/types';
+import type { ExtensionUIDialogOptions, TerminalInputHandler } from '@earendil-works/pi-coding-agent';
+import type {
+  ExtensionEditorHostMessage,
+  ExtensionPromptHostMessage,
+  ExtensionPromptKind,
+  ExtensionUi
+} from '../extensionUi/types';
 import type { TaurenChatControllerOptions } from '../controller/types';
 import type { ThinkingLevelStepDirection } from '../controller/thinkingLevelSteps';
 import type { KwardMemoryAction } from '../kward/memoryActions';
@@ -24,6 +29,10 @@ export type TaurenSessionManagerOptions = TaurenChatControllerOptions & {
   extensionEditor?: {
     isAvailable(): boolean;
     postMessage(message: ExtensionEditorHostMessage): boolean;
+  };
+  extensionPrompt?: {
+    isAvailable(): boolean;
+    postMessage(message: ExtensionPromptHostMessage): boolean;
   };
 };
 
@@ -63,6 +72,16 @@ type PendingExtensionEditor = {
   resolve(value: string | undefined): void;
 };
 
+type PendingExtensionPrompt = {
+  id: string;
+  sessionId: string;
+  kind: ExtensionPromptKind;
+  resolve(value: string | boolean | undefined): void;
+  timeout?: ReturnType<typeof setTimeout>;
+  signal?: AbortSignal;
+  abortHandler?: () => void;
+};
+
 type OpenSession = {
   id: string;
   controller: TaurenChatController;
@@ -95,6 +114,8 @@ export class TaurenSessionManager {
   private composerPasteRevision = 0;
   private extensionEditorSequence = 0;
   private pendingExtensionEditor: PendingExtensionEditor | undefined;
+  private extensionPromptSequence = 0;
+  private pendingExtensionPrompt: PendingExtensionPrompt | undefined;
   private readonly extensionSettings: ExtensionSettings = {
     aboveWidgetsEnabled: true,
     belowWidgetsEnabled: true,
@@ -109,6 +130,7 @@ export class TaurenSessionManager {
   }
 
   public dispose(): void {
+    this.cancelPendingExtensionPrompt();
     this.cancelPendingExtensionEditor();
 
     for (const session of this.sessions.splice(0)) {
@@ -227,6 +249,16 @@ export class TaurenSessionManager {
       return;
     }
 
+    if (message.type === 'extensionPromptAnswer') {
+      this.resolvePendingExtensionPrompt(message.id, message.value);
+      return;
+    }
+
+    if (message.type === 'extensionPromptCancel') {
+      this.resolvePendingExtensionPrompt(message.id, undefined);
+      return;
+    }
+
     await this.active().controller.handleWebviewMessage(message);
   }
 
@@ -325,6 +357,11 @@ export class TaurenSessionManager {
   }
 
   public setCustomUiViewAttached(attached: boolean): void {
+    if (!attached) {
+      this.cancelPendingExtensionPrompt();
+      this.cancelPendingExtensionEditor();
+    }
+
     if (this.customUiViewAttached === attached) {
       return;
     }
@@ -501,6 +538,7 @@ export class TaurenSessionManager {
     const previousActive = this.activeSessionId ? this.active() : undefined;
 
     if (options.activate) {
+      this.cancelPendingExtensionPrompt();
       this.cancelPendingExtensionEditor();
     }
 
@@ -592,6 +630,10 @@ export class TaurenSessionManager {
       this.cancelPendingExtensionEditor();
     }
 
+    if (this.pendingExtensionPrompt && this.pendingExtensionPrompt.sessionId !== id) {
+      this.cancelPendingExtensionPrompt();
+    }
+
     this.activeSessionId = id;
     this.acknowledgeSessionStatusOnOpen(session);
     session.forceFullStatePost = true;
@@ -663,9 +705,24 @@ export class TaurenSessionManager {
     return {
       ...baseUi,
       notify: baseUi?.notify ?? ((message, notifyType) => this.options.showNotification(message, notifyType)),
-      select: baseUi?.select ?? (async () => undefined),
-      confirm: baseUi?.confirm ?? (async () => undefined),
-      input: baseUi?.input ?? (async () => undefined),
+      select: (title, options, dialogOptions) => this.openExtensionPromptForSession(
+        id,
+        { kind: 'select', title, options },
+        dialogOptions,
+        () => baseUi?.select(title, options, dialogOptions)
+      ).then((value) => typeof value === 'string' ? value : undefined),
+      confirm: (title, message, dialogOptions) => this.openExtensionPromptForSession(
+        id,
+        { kind: 'confirm', title, ...(message ? { message } : {}) },
+        dialogOptions,
+        () => baseUi?.confirm(title, message, dialogOptions)
+      ).then((value) => typeof value === 'boolean' ? value : undefined),
+      input: (title, placeholder, dialogOptions) => this.openExtensionPromptForSession(
+        id,
+        { kind: 'input', title, ...(placeholder ? { placeholder } : {}) },
+        dialogOptions,
+        () => baseUi?.input(title, placeholder, dialogOptions)
+      ).then((value) => typeof value === 'string' ? value : undefined),
       ...(customUiHost
         ? { custom: (factory, options) => customUiHost.custom(factory, options) }
         : baseUi?.custom
@@ -704,6 +761,119 @@ export class TaurenSessionManager {
       setEditorText: (text) => this.setEditorTextForSession(id, text),
       pasteToEditor: (text) => this.pasteToEditorForSession(id, text)
     };
+  }
+
+  private async openExtensionPromptForSession(
+    id: string,
+    request: {
+      kind: ExtensionPromptKind;
+      title: string;
+      message?: string;
+      placeholder?: string;
+      options?: string[];
+    },
+    dialogOptions: ExtensionUIDialogOptions | undefined,
+    fallback: () => string | boolean | undefined | PromiseLike<string | boolean | undefined> | undefined
+  ): Promise<string | boolean | undefined> {
+    const extensionPrompt = this.options.extensionPrompt;
+
+    if (dialogOptions?.signal?.aborted) {
+      return undefined;
+    }
+
+    const session = this.showSessionComposer(id);
+
+    if (!session || !extensionPrompt?.isAvailable()) {
+      return await fallback();
+    }
+
+    this.cancelPendingExtensionEditor();
+    this.cancelPendingExtensionPrompt();
+    const promptId = `extension-prompt-${++this.extensionPromptSequence}`;
+    let resolvePrompt: (value: string | boolean | undefined) => void = () => undefined;
+    const result = new Promise<string | boolean | undefined>((resolve) => {
+      resolvePrompt = resolve;
+    });
+    this.pendingExtensionPrompt = {
+      id: promptId,
+      sessionId: id,
+      kind: request.kind,
+      resolve: resolvePrompt
+    };
+    const posted = extensionPrompt.postMessage({
+      type: 'extensionPromptShow',
+      id: promptId,
+      ...request,
+      ...(request.options ? { options: request.options.slice() } : {})
+    });
+
+    if (!posted) {
+      this.resolvePendingExtensionPrompt(promptId, undefined);
+      return await fallback();
+    }
+
+    const pending = this.pendingExtensionPrompt;
+    if (pending?.id === promptId) {
+      if (dialogOptions?.timeout !== undefined) {
+        pending.timeout = setTimeout(
+          () => this.resolvePendingExtensionPrompt(promptId, undefined),
+          Math.max(0, dialogOptions.timeout)
+        );
+      }
+
+      if (dialogOptions?.signal) {
+        pending.signal = dialogOptions.signal;
+        pending.abortHandler = () => this.resolvePendingExtensionPrompt(promptId, undefined);
+        pending.signal.addEventListener('abort', pending.abortHandler, { once: true });
+        if (pending.signal.aborted) {
+          this.resolvePendingExtensionPrompt(promptId, undefined);
+        }
+      }
+    }
+
+    return await result;
+  }
+
+  private resolvePendingExtensionPrompt(id: string, value: string | boolean | undefined): void {
+    const pending = this.pendingExtensionPrompt;
+
+    if (!pending || pending.id !== id) {
+      return;
+    }
+
+    if (value !== undefined) {
+      const expectedType = pending.kind === 'confirm' ? 'boolean' : 'string';
+      if (typeof value !== expectedType) {
+        return;
+      }
+    }
+
+    this.pendingExtensionPrompt = undefined;
+    this.clearPendingExtensionPromptResources(pending);
+    this.options.extensionPrompt?.postMessage({ type: 'extensionPromptHide', id: pending.id });
+    pending.resolve(value);
+  }
+
+  private cancelPendingExtensionPrompt(): void {
+    const pending = this.pendingExtensionPrompt;
+
+    if (!pending) {
+      return;
+    }
+
+    this.pendingExtensionPrompt = undefined;
+    this.clearPendingExtensionPromptResources(pending);
+    this.options.extensionPrompt?.postMessage({ type: 'extensionPromptHide', id: pending.id });
+    pending.resolve(undefined);
+  }
+
+  private clearPendingExtensionPromptResources(pending: PendingExtensionPrompt): void {
+    if (pending.timeout) {
+      clearTimeout(pending.timeout);
+    }
+    if (pending.signal && pending.abortHandler) {
+      pending.signal.removeEventListener('abort', pending.abortHandler);
+    }
   }
 
   private registerTerminalInputHandler(id: string, handler: TerminalInputHandler): () => void {
@@ -771,6 +941,7 @@ export class TaurenSessionManager {
       return Promise.resolve(undefined);
     }
 
+    this.cancelPendingExtensionPrompt();
     const session = this.showSessionComposer(id);
     const extensionEditor = this.options.extensionEditor;
 

--- a/src/sidebar/chatWebview.ts
+++ b/src/sidebar/chatWebview.ts
@@ -324,6 +324,15 @@ export function parseWebviewMessage(value: unknown): WebviewMessage {
       return typeof value.expanded === 'boolean'
         ? { type: 'setToolsExpanded', expanded: value.expanded }
         : { type: 'unknown' };
+    case 'extensionPromptAnswer':
+      return typeof value.id === 'string' && value.id
+        && (typeof value.value === 'string' || typeof value.value === 'boolean')
+        ? { type: 'extensionPromptAnswer', id: value.id, value: value.value }
+        : { type: 'unknown' };
+    case 'extensionPromptCancel':
+      return typeof value.id === 'string' && value.id
+        ? { type: 'extensionPromptCancel', id: value.id }
+        : { type: 'unknown' };
     case 'extensionEditorSave':
       return typeof value.id === 'string' && value.id && typeof value.text === 'string'
         ? { type: 'extensionEditorSave', id: value.id, text: value.text }

--- a/src/sidebar/chatWebviewStyles.ts
+++ b/src/sidebar/chatWebviewStyles.ts
@@ -9,6 +9,7 @@ import { activityStyles } from './styles/activityStyles';
 import { composerStyles } from './styles/composerStyles';
 import { customUiStyles } from './styles/customUiStyles';
 import { extensionEditorStyles } from './styles/extensionEditorStyles';
+import { extensionPromptStyles } from './styles/extensionPromptStyles';
 import { reducedMotionStyles } from './styles/reducedMotionStyles';
 
 export const chatWebviewStyles = [
@@ -23,5 +24,6 @@ export const chatWebviewStyles = [
   composerStyles,
   customUiStyles,
   extensionEditorStyles,
+  extensionPromptStyles,
   reducedMotionStyles,
 ].join('');

--- a/src/sidebar/styles/extensionPromptStyles.ts
+++ b/src/sidebar/styles/extensionPromptStyles.ts
@@ -1,0 +1,171 @@
+export const extensionPromptStyles = /* css */ `    .extension-prompt {
+      margin: 16px 0 2px;
+      padding: 12px;
+      color: var(--vscode-foreground);
+      background: color-mix(in srgb, var(--vscode-input-background) 90%, var(--vscode-focusBorder) 10%);
+      border: 1px solid color-mix(in srgb, var(--vscode-focusBorder) 70%, transparent);
+      border-radius: 10px;
+      box-shadow: inset 3px 0 0 color-mix(in srgb, var(--vscode-focusBorder) 78%, transparent);
+    }
+
+    .extension-prompt[hidden] {
+      display: none;
+    }
+
+    .extension-prompt__header,
+    .extension-prompt__actions {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .extension-prompt__header {
+      justify-content: space-between;
+    }
+
+    .extension-prompt__heading-group {
+      min-width: 0;
+    }
+
+    .extension-prompt__eyebrow {
+      margin-bottom: 3px;
+      color: var(--vscode-descriptionForeground);
+      font-size: 10px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .extension-prompt__title {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 600;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+
+    .extension-prompt__close {
+      display: grid;
+      place-items: center;
+      flex: 0 0 auto;
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      color: var(--vscode-descriptionForeground);
+      background: transparent;
+      border: 0;
+      border-radius: 999px;
+      font: inherit;
+      font-size: 16px;
+      line-height: 1;
+      cursor: pointer;
+    }
+
+    .extension-prompt__close:hover,
+    .extension-prompt__close:focus-visible {
+      color: var(--vscode-foreground);
+      background: color-mix(in srgb, var(--vscode-foreground) 10%, transparent);
+      outline: none;
+    }
+
+    .extension-prompt__body {
+      display: grid;
+      gap: 10px;
+      margin-top: 10px;
+    }
+
+    .extension-prompt__message {
+      margin: 0;
+      color: var(--vscode-descriptionForeground);
+      font-size: 12px;
+      line-height: 1.4;
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+    }
+
+    .extension-prompt__choices {
+      display: grid;
+      gap: 6px;
+    }
+
+    .extension-prompt__choice {
+      width: 100%;
+      min-height: 30px;
+      padding: 6px 9px;
+      color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+      background: var(--vscode-button-secondaryBackground, color-mix(in srgb, var(--vscode-foreground) 8%, transparent));
+      border: 1px solid var(--vscode-button-border, color-mix(in srgb, var(--vscode-foreground) 12%, transparent));
+      border-radius: 6px;
+      font: inherit;
+      line-height: 1.35;
+      text-align: left;
+      overflow-wrap: anywhere;
+      cursor: pointer;
+    }
+
+    .extension-prompt__choice:hover,
+    .extension-prompt__choice:focus-visible {
+      background: var(--vscode-list-hoverBackground, var(--vscode-button-secondaryHoverBackground));
+      border-color: var(--vscode-focusBorder);
+      outline: none;
+    }
+
+    .extension-prompt__input-form {
+      display: grid;
+      gap: 10px;
+    }
+
+    .extension-prompt__input {
+      width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
+      padding: 7px 8px;
+      color: var(--vscode-input-foreground);
+      background: var(--vscode-input-background);
+      border: 1px solid var(--vscode-input-border, transparent);
+      border-radius: 6px;
+      font: inherit;
+      outline: none;
+    }
+
+    .extension-prompt__input:focus {
+      border-color: var(--vscode-focusBorder);
+    }
+
+    .extension-prompt__input::placeholder {
+      color: var(--vscode-input-placeholderForeground, var(--vscode-descriptionForeground));
+    }
+
+    .extension-prompt__actions {
+      justify-content: flex-end;
+    }
+
+    .extension-prompt__button {
+      min-height: 28px;
+      padding: 4px 12px;
+      color: var(--vscode-button-secondaryForeground, var(--vscode-button-foreground));
+      background: var(--vscode-button-secondaryBackground, color-mix(in srgb, var(--vscode-foreground) 10%, transparent));
+      border: 0;
+      border-radius: 6px;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .extension-prompt__button:hover,
+    .extension-prompt__button:focus-visible {
+      background: var(--vscode-button-secondaryHoverBackground, color-mix(in srgb, var(--vscode-foreground) 16%, transparent));
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: 1px;
+    }
+
+    .extension-prompt__button--primary {
+      color: var(--vscode-button-foreground);
+      background: var(--vscode-button-background);
+    }
+
+    .extension-prompt__button--primary:hover,
+    .extension-prompt__button--primary:focus-visible {
+      background: var(--vscode-button-hoverBackground);
+    }
+
+`;

--- a/src/taurenChatViewProvider.ts
+++ b/src/taurenChatViewProvider.ts
@@ -14,7 +14,7 @@ import { KwardClient } from './kward/kwardClient';
 import type { KwardMemoryAction } from './kward/memoryActions';
 import { listAgentSessions } from './sessions/agentSessionList';
 import type { CustomUiHostMessage } from './extensionUi/customUiHost';
-import type { ExtensionEditorHostMessage, ExtensionUi } from './extensionUi/types';
+import type { ExtensionEditorHostMessage, ExtensionPromptHostMessage, ExtensionUi } from './extensionUi/types';
 import { createSessionDiffStatsFileWatcher, readSessionDiffSnapshot, writeSessionDiffSnapshot } from './diff/sessionDiffStorage';
 import { SessionDiffViewer } from './diff/sessionDiffViewer';
 import { ShikiCodeRenderer } from './highlighting/shikiCodeRenderer';
@@ -252,6 +252,10 @@ export class TaurenChatViewProvider implements vscode.WebviewViewProvider, vscod
       extensionEditor: {
         isAvailable: () => Boolean(this.webviewReady && this.webviewView),
         postMessage: (message) => this.postExtensionEditorMessage(message)
+      },
+      extensionPrompt: {
+        isAvailable: () => Boolean(this.webviewReady && this.webviewView),
+        postMessage: (message) => this.postExtensionPromptMessage(message)
       },
       initialSessionMeta: readCachedSessionMeta(this.workspaceState),
       initialSessionFile,
@@ -1173,6 +1177,15 @@ export class TaurenChatViewProvider implements vscode.WebviewViewProvider, vscod
   }
 
   private postExtensionEditorMessage(message: ExtensionEditorHostMessage): boolean {
+    if (!this.webviewReady || !this.webviewView) {
+      return false;
+    }
+
+    void this.webviewView.webview.postMessage(message);
+    return true;
+  }
+
+  private postExtensionPromptMessage(message: ExtensionPromptHostMessage): boolean {
     if (!this.webviewReady || !this.webviewView) {
       return false;
     }

--- a/src/test/suite/chatWebview.test.ts
+++ b/src/test/suite/chatWebview.test.ts
@@ -377,6 +377,18 @@ suite('Chat webview helpers', () => {
       { type: 'setToolsExpanded', expanded: true }
     );
     assert.deepStrictEqual(
+      parseWebviewMessage({ type: 'extensionPromptAnswer', id: 'extension-prompt-1', value: 'Choice A' }),
+      { type: 'extensionPromptAnswer', id: 'extension-prompt-1', value: 'Choice A' }
+    );
+    assert.deepStrictEqual(
+      parseWebviewMessage({ type: 'extensionPromptAnswer', id: 'extension-prompt-2', value: true }),
+      { type: 'extensionPromptAnswer', id: 'extension-prompt-2', value: true }
+    );
+    assert.deepStrictEqual(
+      parseWebviewMessage({ type: 'extensionPromptCancel', id: 'extension-prompt-3' }),
+      { type: 'extensionPromptCancel', id: 'extension-prompt-3' }
+    );
+    assert.deepStrictEqual(
       parseWebviewMessage({ type: 'extensionEditorSave', id: 'extension-editor-1', text: '' }),
       { type: 'extensionEditorSave', id: 'extension-editor-1', text: '' }
     );
@@ -456,6 +468,9 @@ suite('Chat webview helpers', () => {
     assert.deepStrictEqual(parseWebviewMessage({ type: 'extensionEditorSave', id: '', text: 'x' }), { type: 'unknown' });
     assert.deepStrictEqual(parseWebviewMessage({ type: 'extensionEditorSave', id: 'extension-editor-1', text: 42 }), { type: 'unknown' });
     assert.deepStrictEqual(parseWebviewMessage({ type: 'extensionEditorCancel', id: '' }), { type: 'unknown' });
+    assert.deepStrictEqual(parseWebviewMessage({ type: 'extensionPromptAnswer', id: '', value: 'x' }), { type: 'unknown' });
+    assert.deepStrictEqual(parseWebviewMessage({ type: 'extensionPromptAnswer', id: 'extension-prompt-1', value: 42 }), { type: 'unknown' });
+    assert.deepStrictEqual(parseWebviewMessage({ type: 'extensionPromptCancel', id: '' }), { type: 'unknown' });
     assert.deepStrictEqual(parseWebviewMessage({ type: 'submit', text: 'hello', streamingBehavior: 'later' }), { type: 'unknown' });
     assert.deepStrictEqual(
       parseWebviewMessage({ type: 'setModel', provider: 'openai' }),

--- a/src/test/suite/extensionPrompt.test.ts
+++ b/src/test/suite/extensionPrompt.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import { isExtensionPromptHostMessage } from '../../webview/extensionPrompt';
+
+suite('Pi extension prompt', () => {
+  test('accepts supported inline prompt host messages', () => {
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-1',
+      kind: 'select',
+      title: 'Choose',
+      options: ['A', 'B']
+    }), true);
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-2',
+      kind: 'confirm',
+      title: 'Continue?',
+      message: 'Apply the changes now?'
+    }), true);
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-3',
+      kind: 'input',
+      title: 'Name',
+      placeholder: 'Feature name'
+    }), true);
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptHide',
+      id: 'extension-prompt-3'
+    }), true);
+  });
+
+  test('rejects malformed prompt host messages', () => {
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptShow',
+      id: '',
+      kind: 'select',
+      title: 'Choose',
+      options: ['A']
+    }), false);
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-1',
+      kind: 'select',
+      title: 'Choose',
+      options: ['A', 2]
+    }), false);
+    assert.strictEqual(isExtensionPromptHostMessage({
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-1',
+      kind: 'unknown',
+      title: 'Choose'
+    }), false);
+  });
+});

--- a/src/test/suite/taurenSessionManager.test.ts
+++ b/src/test/suite/taurenSessionManager.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { TaurenSessionManager, type TaurenSessionManagerOptions } from '../../sessions/taurenSessionManager';
 import type { CustomUiHostMessage } from '../../extensionUi/customUiHost';
-import type { ExtensionEditorHostMessage } from '../../extensionUi/types';
+import type { ExtensionEditorHostMessage, ExtensionPromptHostMessage } from '../../extensionUi/types';
 import type { WebviewSessionItem, WebviewStateMessage, WebviewTreeItem } from '../../webviewProtocol/types';
 import type { SettingValue, TaurenSettingId } from '../../settings/settingsRegistry';
 import type { PiClient } from '../../pi/clientTypes';
@@ -602,6 +602,79 @@ suite('TaurenSessionManager', () => {
 
     await harness.manager.handleWebviewMessage({ type: 'extensionEditorCancel', id: 'extension-editor-2' });
     assert.strictEqual(await cancelPromise, undefined);
+    harness.manager.dispose();
+  });
+
+  test('resolves Pi extension prompts through the active Transcript', async () => {
+    const harness = createManagerHarness([new FakePiClient()]);
+
+    await harness.manager.handleWebviewMessage({ type: 'submit', text: 'hello' });
+    const extensionUi = harness.clientOptions[0].extensionUi;
+    assert.ok(extensionUi);
+
+    const selectPromise = extensionUi.select('Choose a path', ['Safe migration', 'Fast migration']);
+    assert.deepStrictEqual(harness.extensionPromptMessages.at(-1), {
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-1',
+      kind: 'select',
+      title: 'Choose a path',
+      options: ['Safe migration', 'Fast migration']
+    });
+    await harness.manager.handleWebviewMessage({
+      type: 'extensionPromptAnswer',
+      id: 'extension-prompt-1',
+      value: 'Safe migration'
+    });
+    assert.strictEqual(await selectPromise, 'Safe migration');
+    assert.deepStrictEqual(harness.extensionPromptMessages.at(-1), {
+      type: 'extensionPromptHide',
+      id: 'extension-prompt-1'
+    });
+
+    const confirmPromise = extensionUi.confirm('Apply changes?', 'This will update three files.');
+    assert.deepStrictEqual(harness.extensionPromptMessages.at(-1), {
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-2',
+      kind: 'confirm',
+      title: 'Apply changes?',
+      message: 'This will update three files.'
+    });
+    await harness.manager.handleWebviewMessage({
+      type: 'extensionPromptAnswer',
+      id: 'extension-prompt-2',
+      value: true
+    });
+    assert.strictEqual(await confirmPromise, true);
+
+    const inputPromise = extensionUi.input('Branch name', 'feature/inline-prompts');
+    assert.deepStrictEqual(harness.extensionPromptMessages.at(-1), {
+      type: 'extensionPromptShow',
+      id: 'extension-prompt-3',
+      kind: 'input',
+      title: 'Branch name',
+      placeholder: 'feature/inline-prompts'
+    });
+    await harness.manager.handleWebviewMessage({ type: 'extensionPromptCancel', id: 'extension-prompt-3' });
+    assert.strictEqual(await inputPromise, undefined);
+    harness.manager.dispose();
+  });
+
+  test('dismisses an inline Pi extension prompt when its signal aborts', async () => {
+    const harness = createManagerHarness([new FakePiClient()]);
+
+    await harness.manager.handleWebviewMessage({ type: 'submit', text: 'hello' });
+    const extensionUi = harness.clientOptions[0].extensionUi;
+    assert.ok(extensionUi);
+    const controller = new AbortController();
+    const promptPromise = extensionUi.select('Choose quickly', ['A', 'B'], { signal: controller.signal });
+
+    controller.abort();
+
+    assert.strictEqual(await promptPromise, undefined);
+    assert.deepStrictEqual(harness.extensionPromptMessages.at(-1), {
+      type: 'extensionPromptHide',
+      id: 'extension-prompt-1'
+    });
     harness.manager.dispose();
   });
 
@@ -1242,6 +1315,7 @@ type ManagerHarness = {
   clientOptions: PiClientOptions[];
   customUiMessages: CustomUiHostMessage[];
   extensionEditorMessages: ExtensionEditorHostMessage[];
+  extensionPromptMessages: ExtensionPromptHostMessage[];
   taurenSettings: Partial<Record<TaurenSettingId, SettingValue>>;
   readonly createCalls: number;
 };
@@ -1264,6 +1338,7 @@ function createManagerHarness(
   const clientOptions: PiClientOptions[] = [];
   const customUiMessages: CustomUiHostMessage[] = [];
   const extensionEditorMessages: ExtensionEditorHostMessage[] = [];
+  const extensionPromptMessages: ExtensionPromptHostMessage[] = [];
   const taurenSettings: Partial<Record<TaurenSettingId, SettingValue>> = { ...(options.taurenSettings ?? {}) };
   const pendingClients = [...clients];
   let createCalls = 0;
@@ -1302,6 +1377,13 @@ function createManagerHarness(
         return true;
       }
     },
+    extensionPrompt: {
+      isAvailable: () => true,
+      postMessage: (message) => {
+        extensionPromptMessages.push(message);
+        return true;
+      }
+    },
     extensionUi: {
       notify: (message, type) => notifications.push({ message, type }),
       select: async () => undefined,
@@ -1317,6 +1399,7 @@ function createManagerHarness(
     clientOptions,
     customUiMessages,
     extensionEditorMessages,
+    extensionPromptMessages,
     taurenSettings,
     get createCalls(): number {
       return createCalls;

--- a/src/webview/extensionPrompt.ts
+++ b/src/webview/extensionPrompt.ts
@@ -1,0 +1,240 @@
+import type { WebviewApi } from './types';
+
+type ExtensionPromptKind = 'select' | 'confirm' | 'input';
+
+type ExtensionPromptHostMessage =
+  | {
+    type: 'extensionPromptShow';
+    id: string;
+    kind: ExtensionPromptKind;
+    title: string;
+    message?: string;
+    placeholder?: string;
+    options?: string[];
+  }
+  | { type: 'extensionPromptHide'; id: string };
+
+export type ExtensionPromptControllerOptions = {
+  vscode: WebviewApi;
+  element: HTMLElement;
+  onShow(): void;
+};
+
+export class ExtensionPromptController {
+  private activeId: string | undefined;
+
+  public constructor(private readonly options: ExtensionPromptControllerOptions) {}
+
+  public handleHostMessage(message: unknown): boolean {
+    if (!isExtensionPromptHostMessage(message)) {
+      return false;
+    }
+
+    if (message.type === 'extensionPromptShow') {
+      this.show(message);
+      return true;
+    }
+
+    if (!this.activeId || message.id === this.activeId) {
+      this.hide();
+    }
+
+    return true;
+  }
+
+  public handleGlobalKeydown(event: KeyboardEvent): boolean {
+    if (!this.isActive() || event.key !== 'Escape') {
+      return false;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.cancel();
+    return true;
+  }
+
+  public isActive(): boolean {
+    return Boolean(this.activeId) && !this.options.element.hidden;
+  }
+
+  private show(message: Extract<ExtensionPromptHostMessage, { type: 'extensionPromptShow' }>): void {
+    this.activeId = message.id;
+    const header = document.createElement('header');
+    header.className = 'extension-prompt__header';
+    const headingGroup = document.createElement('div');
+    headingGroup.className = 'extension-prompt__heading-group';
+    const eyebrow = document.createElement('div');
+    eyebrow.className = 'extension-prompt__eyebrow';
+    eyebrow.textContent = 'Pi needs your input';
+    const title = document.createElement('h3');
+    title.className = 'extension-prompt__title';
+    title.textContent = message.title || 'Choose a response';
+    headingGroup.append(eyebrow, title);
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.className = 'extension-prompt__close';
+    close.setAttribute('aria-label', 'Cancel Pi prompt');
+    close.textContent = '×';
+    close.addEventListener('click', () => this.cancel());
+    header.append(headingGroup, close);
+
+    const body = document.createElement('div');
+    body.className = 'extension-prompt__body';
+    if (message.message) {
+      const detail = document.createElement('p');
+      detail.className = 'extension-prompt__message';
+      detail.textContent = message.message;
+      body.append(detail);
+    }
+
+    if (message.kind === 'select') {
+      body.append(this.createChoiceList(message.id, message.options ?? []));
+    } else if (message.kind === 'confirm') {
+      body.append(this.createConfirmActions(message.id));
+    } else {
+      body.append(this.createInputForm(message.id, message.placeholder));
+    }
+
+    this.options.element.replaceChildren(header, body);
+    this.options.element.hidden = false;
+    this.options.element.inert = false;
+    this.options.onShow();
+    requestAnimationFrame(() => {
+      this.options.element.querySelector<HTMLElement>('button:not(.extension-prompt__close), input')?.focus({ preventScroll: true });
+    });
+  }
+
+  private createChoiceList(id: string, choices: string[]): HTMLElement {
+    const list = document.createElement('div');
+    list.className = 'extension-prompt__choices';
+    list.setAttribute('role', 'list');
+
+    for (const choice of choices) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'extension-prompt__choice';
+      button.textContent = choice;
+      button.addEventListener('click', () => this.answer(id, choice));
+      button.addEventListener('keydown', (event) => this.moveChoiceFocus(event));
+      const item = document.createElement('div');
+      item.setAttribute('role', 'listitem');
+      item.append(button);
+      list.append(item);
+    }
+
+    if (choices.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'extension-prompt__message';
+      empty.textContent = 'No choices are available.';
+      list.append(empty);
+    }
+
+    return list;
+  }
+
+  private createConfirmActions(id: string): HTMLElement {
+    const actions = document.createElement('div');
+    actions.className = 'extension-prompt__actions';
+    const no = this.createActionButton('No', false, () => this.answer(id, false));
+    const yes = this.createActionButton('Yes', true, () => this.answer(id, true));
+    actions.append(no, yes);
+    return actions;
+  }
+
+  private createInputForm(id: string, placeholder: string | undefined): HTMLElement {
+    const form = document.createElement('form');
+    form.className = 'extension-prompt__input-form';
+    const input = document.createElement('input');
+    input.className = 'extension-prompt__input';
+    input.type = 'text';
+    input.placeholder = placeholder ?? '';
+    input.setAttribute('aria-label', placeholder || 'Response');
+    const actions = document.createElement('div');
+    actions.className = 'extension-prompt__actions';
+    const cancel = this.createActionButton('Cancel', false, () => this.cancel());
+    const submit = this.createActionButton('Submit', true);
+    submit.type = 'submit';
+    actions.append(cancel, submit);
+    form.append(input, actions);
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this.answer(id, input.value);
+    });
+    return form;
+  }
+
+  private createActionButton(label: string, primary: boolean, onClick?: () => void): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `extension-prompt__button${primary ? ' extension-prompt__button--primary' : ''}`;
+    button.textContent = label;
+    if (onClick) {
+      button.addEventListener('click', onClick);
+    }
+    return button;
+  }
+
+  private moveChoiceFocus(event: KeyboardEvent): void {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+      return;
+    }
+
+    const buttons = Array.from(this.options.element.querySelectorAll<HTMLButtonElement>('.extension-prompt__choice'));
+    const currentIndex = buttons.indexOf(event.currentTarget as HTMLButtonElement);
+    if (currentIndex < 0 || buttons.length === 0) {
+      return;
+    }
+
+    event.preventDefault();
+    const delta = event.key === 'ArrowDown' ? 1 : -1;
+    buttons[(currentIndex + delta + buttons.length) % buttons.length]?.focus();
+  }
+
+  private answer(id: string, value: string | boolean): void {
+    if (this.activeId !== id) {
+      return;
+    }
+
+    this.hide();
+    this.options.vscode.postMessage({ type: 'extensionPromptAnswer', id, value });
+  }
+
+  private cancel(): void {
+    if (!this.activeId) {
+      return;
+    }
+
+    const id = this.activeId;
+    this.hide();
+    this.options.vscode.postMessage({ type: 'extensionPromptCancel', id });
+  }
+
+  private hide(): void {
+    this.activeId = undefined;
+    this.options.element.hidden = true;
+    this.options.element.inert = true;
+    this.options.element.replaceChildren();
+  }
+}
+
+export function isExtensionPromptHostMessage(message: unknown): message is ExtensionPromptHostMessage {
+  if (!message || typeof message !== 'object') {
+    return false;
+  }
+
+  const value = message as Record<string, unknown>;
+  if (value.type === 'extensionPromptHide') {
+    return typeof value.id === 'string' && value.id.length > 0;
+  }
+
+  if (value.type !== 'extensionPromptShow'
+    || typeof value.id !== 'string' || !value.id
+    || (value.kind !== 'select' && value.kind !== 'confirm' && value.kind !== 'input')
+    || typeof value.title !== 'string') {
+    return false;
+  }
+
+  return (value.message === undefined || typeof value.message === 'string')
+    && (value.placeholder === undefined || typeof value.placeholder === 'string')
+    && (value.options === undefined || (Array.isArray(value.options) && value.options.every((option) => typeof option === 'string')));
+}

--- a/src/webview/main.ts
+++ b/src/webview/main.ts
@@ -8,6 +8,7 @@ import { configureMarkdownImageRendering, handleMarkdownImageMessage } from './m
 import { ComposerController } from './composer/composer';
 import { CustomUiController } from './customUI/customUi';
 import { ExtensionEditorDialogController } from './extensionEditorDialog';
+import { ExtensionPromptController } from './extensionPrompt';
 import { eventTargetElement, getWebviewDom, parseCssPixelValue } from './dom';
 import { MessageListController } from './messages/messageList';
 import { TranscriptSearchController } from './messages/transcriptSearch';
@@ -118,7 +119,13 @@ busyStatusSpinnerElement.setAttribute('aria-hidden', 'true');
 const busyStatusTextElement = document.createElement('span');
 busyStatusElement.append(busyStatusSpinnerElement, busyStatusTextElement);
 messagesContentElement.replaceChildren(...Array.from(messagesElement.childNodes));
-messagesElement.append(messagesContentElement, busyStatusElement);
+const extensionPromptElement = document.createElement('article');
+extensionPromptElement.className = 'extension-prompt';
+extensionPromptElement.hidden = true;
+extensionPromptElement.inert = true;
+extensionPromptElement.setAttribute('aria-live', 'polite');
+extensionPromptElement.setAttribute('aria-label', 'Pi extension prompt');
+messagesElement.append(messagesContentElement, busyStatusElement, extensionPromptElement);
 
 const kwardQuestionElement = document.createElement('section');
 kwardQuestionElement.className = 'kward-question';
@@ -178,6 +185,12 @@ const messagesController = new MessageListController({
   messagesContentElement,
   busyStatusElement,
   busyStatusTextElement
+});
+
+const extensionPromptController = new ExtensionPromptController({
+  vscode,
+  element: extensionPromptElement,
+  onShow: () => messagesController.scheduleMessagesToBottom()
 });
 
 transcriptSearchController = new TranscriptSearchController({
@@ -258,6 +271,10 @@ messagesElement.addEventListener('click', (event) => messagesController.handleMe
 messagesElement.addEventListener('scroll', () => messagesController.handleMessagesScroll());
 
 window.addEventListener('message', (event) => {
+  if (extensionPromptController.handleHostMessage(event.data)) {
+    return;
+  }
+
   if (extensionEditorDialogController.handleHostMessage(event.data)) {
     return;
   }
@@ -431,6 +448,10 @@ window.addEventListener('click', (event) => {
 });
 
 window.addEventListener('keydown', (event) => {
+  if (extensionPromptController.handleGlobalKeydown(event)) {
+    return;
+  }
+
   if (extensionEditorDialogController.handleGlobalKeydown(event)) {
     return;
   }
@@ -1711,7 +1732,7 @@ function handleCustomUiClose(): void {
   }
 
   requestAnimationFrame(() => {
-    if (state.lane === 'chat' && !customUiController.isActive()) {
+    if (state.lane === 'chat' && !customUiController.isActive() && !extensionPromptController.isActive()) {
       textarea.focus({ preventScroll: true });
     }
   });
@@ -1719,6 +1740,10 @@ function handleCustomUiClose(): void {
 
 function focusPromptInput(): void {
   requestAnimationFrame(() => {
+    if (extensionPromptController.isActive()) {
+      return;
+    }
+
     if (customUiController.focusInput()) {
       return;
     }

--- a/src/webviewProtocol/types.ts
+++ b/src/webviewProtocol/types.ts
@@ -210,6 +210,8 @@ export type WebviewMessage =
   | { type: 'extensionFooterDimensions'; columns: number; rows: number; cellWidthPx?: number; cellHeightPx?: number }
   | { type: 'extensionTerminalInput'; data: string }
   | { type: 'setToolsExpanded'; expanded: boolean }
+  | { type: 'extensionPromptAnswer'; id: string; value: string | boolean }
+  | { type: 'extensionPromptCancel'; id: string }
   | { type: 'extensionEditorSave'; id: string; text: string }
   | { type: 'extensionEditorCancel'; id: string }
   | { type: 'submit'; text: string; streamingBehavior?: WebviewStreamingBehavior }


### PR DESCRIPTION
Rendered Pi extension choices, confirmations, and text questions as inline Transcript Entries instead of native VS Code prompts.