### PR TITLE
Preserve sidebar webview state when panel is hidden and re-shown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   context.subscriptions.push(
     provider,
-    vscode.window.registerWebviewViewProvider(taurenChatViewType, provider),
+    vscode.window.registerWebviewViewProvider(taurenChatViewType, provider, { webviewOptions: { retainContextWhenHidden: true } }),
     vscode.commands.registerCommand('tauren.newSession', () => provider.newSession()),
     vscode.commands.registerCommand('tauren.resume', () => provider.resume()),
     vscode.commands.registerCommand('tauren.fork', () => provider.fork()),


### PR DESCRIPTION
Add `retainContextWhenHidden` option so that VSCode doesn't destroy the webview when the sidebar is hidden (e.g. toggling sidebar, switching to other pane such as file browser or revision control). This avoids re-rendering (which can easily drain battery life) on sessions with lengthy contexts and clears out the prompt editor, cursor position, etc.