### PR TITLE
(proposal): Edits are shown as a side-by-side diff. Each edit can be accepted or rejected

### DIFF
--- a/BEES.md
+++ b/BEES.md
@@ -1,0 +1,1 @@
+Bees are fascinating because they communicate through dance — the waggle dance precisely tells their hivemates exactly where to find flowers.

--- a/BEES.md
+++ b/BEES.md
@@ -1,1 +1,0 @@
-Bees are fascinating because they communicate through dance — the waggle dance precisely tells their hivemates exactly where to find flowers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- AI edit diff view: when the Pi agent runs a `write` or `edit` tool, Tauren automatically opens a native VS Code side-by-side diff showing the before/after changes. Accept (✓) or Reject (✗) buttons appear in the diff editor's title bar to apply or discard the suggestion.
-
-### Fixed
-- AI edit diff view: the file is now restored to its original content immediately after the agent writes it, so the workspace is unchanged until the user explicitly clicks Accept. Clicking Reject leaves the original file in place, closes the diff tab, and notifies the AI that the change was rejected.
+- AI edit diff view: when the Pi agent runs a `write` or `edit` tool, Tauren automatically opens a VS Code side-by-side diff showing the before/after changes. Accept (✓) or Reject (✗) buttons appear in the diff editor's title bar to apply or discard the suggestion.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - AI edit diff view: when the Pi agent runs a `write` or `edit` tool, Tauren automatically opens a native VS Code side-by-side diff showing the before/after changes. Accept (✓) or Reject (✗) buttons appear in the diff editor's title bar to apply or discard the suggestion.
 
+### Fixed
+- AI edit diff view: the file is now restored to its original content immediately after the agent writes it, so the workspace is unchanged until the user explicitly clicks Accept. Clicking Reject leaves the original file in place, closes the diff tab, and notifies the AI that the change was rejected.
+
 ### Changed
 
 - Made the `/reload` progress message neutral for both Pi and Kward backends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- AI edit diff view: when the Pi agent runs a `write` or `edit` tool, Tauren automatically opens a native VS Code side-by-side diff showing the before/after changes. Accept (✓) or Reject (✗) buttons appear in the diff editor's title bar to apply or discard the suggestion.
+
 ### Changed
 
 - Made the `/reload` progress message neutral for both Pi and Kward backends.

--- a/package.json
+++ b/package.json
@@ -239,6 +239,18 @@
         "command": "tauren.showDiagnostics",
         "title": "Show Diagnostics",
         "category": "Tauren"
+      },
+      {
+        "command": "tauren.acceptProposedEdit",
+        "title": "Accept AI Suggestion",
+        "category": "Tauren",
+        "icon": "$(check)"
+      },
+      {
+        "command": "tauren.rejectProposedEdit",
+        "title": "Reject AI Suggestion",
+        "category": "Tauren",
+        "icon": "$(close)"
       }
     ],
     "viewsContainers": {
@@ -261,6 +273,18 @@
       ]
     },
     "menus": {
+      "editor/title": [
+        {
+          "command": "tauren.acceptProposedEdit",
+          "when": "resourceScheme == tauren-proposed",
+          "group": "navigation@1"
+        },
+        {
+          "command": "tauren.rejectProposedEdit",
+          "when": "resourceScheme == tauren-proposed",
+          "group": "navigation@2"
+        }
+      ],
       "editor/context": [
         {
           "command": "tauren.addContext",

--- a/src/controller/piEventHandler.ts
+++ b/src/controller/piEventHandler.ts
@@ -27,6 +27,7 @@ export type AgentRuntimeEventHandlerOptions = {
   refreshSessionDiffStats: () => void;
   refreshContextUsage: () => void;
   refreshModelCatalog: () => void;
+  captureBeforeToolExecution?: (event: AgentRuntimeEvent) => void;
   addToolExecution: (event: AgentRuntimeEvent) => void;
   armQueuedReadyScriptRun: () => void;
   runReadyScriptAfterAgentEnd: () => void;
@@ -121,6 +122,7 @@ export class AgentRuntimeEventHandler {
         break;
       case 'tool_execution_start':
         this.applyPiActivity(event);
+        this.options.captureBeforeToolExecution?.(this.enrichLiveToolExecutionEvent(event));
         this.options.postState();
         break;
       case 'tool_execution_update':

--- a/src/controller/types.ts
+++ b/src/controller/types.ts
@@ -56,6 +56,8 @@ export type TaurenChatControllerOptions = {
   restartOpenSessions?: () => Promise<number>;
   hasBusyOpenSession?: () => boolean;
   showSessionChanges?: (sessionPath: string, displayName: string) => Promise<void>;
+  captureBeforeProposedEditDiff?: (toolExecutionInput: unknown) => Promise<void>;
+  showProposedEditDiff?: (toolExecutionInput: unknown) => Promise<void>;
   loadSessionDiffSnapshot?: (sessionFile: string) => SessionDiffSnapshot | undefined;
   saveSessionDiffSnapshot?: (sessionFile: string, snapshot: SessionDiffSnapshot) => void;
   voiceController?: VoiceController;

--- a/src/diff/proposedEditDiff.ts
+++ b/src/diff/proposedEditDiff.ts
@@ -1,0 +1,433 @@
+import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import * as vscode from 'vscode';
+import { proposedEditScheme, ProposedEditProvider } from './proposedEditProvider';
+import { isRecord } from '../shared/typeGuards';
+
+/**
+ * Pending diff waiting for an accept/reject decision.
+ */
+type PendingProposedEdit = {
+  absolutePath: string;
+  /** The content that was on disk before the agent ran the tool. */
+  originalContent: string;
+  proposedContent: string;
+  originalUri: vscode.Uri;
+  proposedUri: vscode.Uri;
+  isNewFile: boolean;
+};
+
+/**
+ * Content captured from a file just before a tool execution starts, keyed by
+ * absolute path.  Used to restore the file after the agent writes it and to
+ * build the "before" side of the diff.
+ */
+type PreExecutionSnapshot = {
+  originalContent: string;
+  isNewFile: boolean;
+};
+
+function getRecordString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Resolves the absolute path for a tool-call file argument, given the session
+ * cwd.  Returns undefined if the path cannot be resolved.
+ */
+function resolveAbsolutePath(cwd: string | undefined, filePath: string): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+
+  if (path.isAbsolute(filePath)) {
+    return filePath;
+  }
+
+  if (!cwd) {
+    return undefined;
+  }
+
+  return path.resolve(cwd, filePath);
+}
+
+/**
+ * Applies a sequence of `edit` tool edits (oldText → newText) to `original`
+ * content, returning the resulting string.  Returns undefined if any
+ * substitution cannot be applied uniquely.
+ */
+function applyEdits(
+  original: string,
+  edits: Array<{ oldText: string; newText: string }>
+): string | undefined {
+  let content = original;
+
+  for (const edit of edits) {
+    const index = content.indexOf(edit.oldText);
+
+    if (index === -1) {
+      return undefined;
+    }
+
+    // Ensure uniqueness – the same oldText must not appear a second time
+    if (content.indexOf(edit.oldText, index + edit.oldText.length) !== -1) {
+      return undefined;
+    }
+
+    content = `${content.slice(0, index)}${edit.newText}${content.slice(index + edit.oldText.length)}`;
+  }
+
+  return content;
+}
+
+/**
+ * Manages the lifecycle of proposed-edit diff views.
+ *
+ * Flow:
+ *  1. Call `captureBeforeToolExecution` at `tool_execution_start` to snapshot
+ *     the file before the agent modifies it.
+ *  2. Call `handleToolExecution` at `tool_execution_end`.  It reads the
+ *     agent-written content from disk as the "proposed" side, restores the
+ *     original file so the workspace is unchanged, then opens the diff.
+ *  3. The user clicks Accept (→ `acceptPendingEdit`) to apply the proposed
+ *     content, or Reject (→ `rejectPendingEdit`) to leave the restored
+ *     original in place.
+ *
+ * Bind `acceptPendingEdit` / `rejectPendingEdit` to the Accept / Reject
+ * commands registered in package.json.
+ */
+export class ProposedEditDiffService implements vscode.Disposable {
+  private pendingEdits = new Map<string, PendingProposedEdit>();
+  /** Snapshots keyed by absolute path, captured before each tool execution. */
+  private preExecutionSnapshots = new Map<string, PreExecutionSnapshot>();
+  private nonce = 0;
+
+  public constructor(
+    private readonly provider: ProposedEditProvider,
+    private readonly getCwd: () => string | undefined
+  ) {}
+
+  public dispose(): void {
+    this.pendingEdits.clear();
+    this.preExecutionSnapshots.clear();
+  }
+
+  /**
+   * Called at `tool_execution_start` to capture the file's current content
+   * before the agent modifies it.  `input` is the raw event object.
+   */
+  public async captureBeforeToolExecution(input: unknown): Promise<void> {
+    if (!isRecord(input)) {
+      return;
+    }
+
+    const toolName = getRecordString(input, 'toolName');
+
+    if (toolName !== 'write' && toolName !== 'edit') {
+      return;
+    }
+
+    const args = isRecord(input.args) ? input.args : undefined;
+
+    if (!args) {
+      return;
+    }
+
+    const filePath = getRecordString(args, 'path') ?? getRecordString(args, 'file_path');
+
+    if (!filePath) {
+      return;
+    }
+
+    const cwd = this.getCwd();
+    const absolutePath = resolveAbsolutePath(cwd, filePath);
+
+    if (!absolutePath) {
+      return;
+    }
+
+    let originalContent: string;
+    let isNewFile: boolean;
+
+    try {
+      originalContent = await fs.readFile(absolutePath, 'utf8');
+      isNewFile = false;
+    } catch {
+      // File does not exist yet
+      originalContent = '';
+      isNewFile = true;
+    }
+
+    this.preExecutionSnapshots.set(absolutePath, { originalContent, isNewFile });
+  }
+
+  /**
+   * Called at `tool_execution_end`.  Reads the agent-written content as the
+   * "proposed" side, restores the original file so the workspace is unchanged,
+   * then opens the diff view.
+   */
+  public async handleToolExecution(input: unknown): Promise<void> {
+    if (!isRecord(input)) {
+      return;
+    }
+
+    const toolName = getRecordString(input, 'toolName');
+
+    if (toolName !== 'write' && toolName !== 'edit') {
+      return;
+    }
+
+    if (input.isError === true) {
+      return;
+    }
+
+    const args = isRecord(input.args) ? input.args : undefined;
+
+    if (!args) {
+      return;
+    }
+
+    const filePath = getRecordString(args, 'path') ?? getRecordString(args, 'file_path');
+
+    if (!filePath) {
+      return;
+    }
+
+    const cwd = this.getCwd();
+    const absolutePath = resolveAbsolutePath(cwd, filePath);
+
+    if (!absolutePath) {
+      return;
+    }
+
+    // Retrieve (and remove) the pre-execution snapshot
+    const snapshot = this.preExecutionSnapshots.get(absolutePath);
+    this.preExecutionSnapshots.delete(absolutePath);
+
+    if (toolName === 'write') {
+      const proposedContent = getRecordString(args, 'content') ?? getRecordString(args, 'text');
+
+      if (proposedContent === undefined) {
+        return;
+      }
+
+      const originalContent = snapshot?.originalContent ?? '';
+      const isNewFile = snapshot?.isNewFile ?? true;
+      await this.revertFileThenOpenDiff(absolutePath, originalContent, proposedContent, isNewFile);
+      return;
+    }
+
+    // toolName === 'edit'
+    const rawEdits = args.edits;
+
+    if (!Array.isArray(rawEdits)) {
+      return;
+    }
+
+    const edits: Array<{ oldText: string; newText: string }> = [];
+
+    for (const rawEdit of rawEdits) {
+      if (!isRecord(rawEdit)) {
+        continue;
+      }
+
+      const oldText = getRecordString(rawEdit, 'oldText');
+      const newText = getRecordString(rawEdit, 'newText');
+
+      if (oldText !== undefined && newText !== undefined) {
+        edits.push({ oldText, newText });
+      }
+    }
+
+    if (edits.length === 0) {
+      return;
+    }
+
+    // Use the pre-execution snapshot as the original.  If no snapshot was
+    // captured (e.g. tool_execution_start was missed), fall back to reading
+    // the current file and computing proposed from the edits the usual way.
+    if (snapshot) {
+      const { originalContent, isNewFile } = snapshot;
+      const proposedContent = applyEdits(originalContent, edits);
+
+      if (proposedContent === undefined) {
+        // Cannot reconstruct (non-unique match), restore original and skip diff
+        await this.writeFileContent(absolutePath, originalContent, isNewFile);
+        return;
+      }
+
+      await this.revertFileThenOpenDiff(absolutePath, originalContent, proposedContent, isNewFile);
+      return;
+    }
+
+    // Fallback: no pre-execution snapshot available.
+    // Read the already-edited file content and compute original by reversing edits.
+    let currentContent: string;
+
+    try {
+      currentContent = await fs.readFile(absolutePath, 'utf8');
+    } catch {
+      return;
+    }
+
+    // We cannot reliably reverse edits, so show the diff with the current
+    // (already-edited) file as "proposed" and skip restoration.
+    const nonce = ++this.nonce;
+    const proposedUri = vscode.Uri.parse(
+      `${proposedEditScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
+    );
+    this.provider.set(proposedUri, currentContent);
+
+    const pending: PendingProposedEdit = {
+      absolutePath,
+      originalContent: currentContent,
+      proposedContent: currentContent,
+      originalUri: vscode.Uri.file(absolutePath),
+      proposedUri,
+      isNewFile: false
+    };
+    this.pendingEdits.set(absolutePath, pending);
+
+    const filename = path.basename(absolutePath);
+    await vscode.commands.executeCommand(
+      'vscode.diff',
+      vscode.Uri.file(absolutePath),
+      proposedUri,
+      `${filename} ↔ AI Suggestion`,
+      { preview: true }
+    );
+  }
+
+  /**
+   * Writes the accepted proposed content to disk and cleans up the diff view.
+   */
+  public async acceptPendingEdit(absolutePath: string): Promise<void> {
+    const pending = this.pendingEdits.get(absolutePath);
+
+    if (!pending) {
+      return;
+    }
+
+    await this.writeFileContent(absolutePath, pending.proposedContent, pending.isNewFile);
+    this.cleanupPending(pending);
+  }
+
+  /**
+   * Leaves the original (already-restored) file in place and cleans up the
+   * diff view.
+   */
+  public rejectPendingEdit(absolutePath: string): void {
+    const pending = this.pendingEdits.get(absolutePath);
+
+    if (!pending) {
+      return;
+    }
+
+    this.cleanupPending(pending);
+    vscode.window.showInformationMessage(`Tauren: Proposed edit to ${path.basename(absolutePath)} was rejected.`);
+  }
+
+  // ─── private ────────────────────────────────────────────────────────────────
+
+  /**
+   * Restores the file to `originalContent` on disk (undoing the agent's write),
+   * then opens the side-by-side diff.
+   */
+  private async revertFileThenOpenDiff(
+    absolutePath: string,
+    originalContent: string,
+    proposedContent: string,
+    isNewFile: boolean
+  ): Promise<void> {
+    // Restore the file so the workspace reflects the original state
+    if (isNewFile) {
+      // Delete the newly created file so the left side of the diff is truly empty
+      try {
+        await fs.unlink(absolutePath);
+      } catch {
+        // Already gone or couldn't delete — not fatal
+      }
+    } else {
+      await this.writeFileContent(absolutePath, originalContent, false);
+    }
+
+    const nonce = ++this.nonce;
+
+    // Left side: original file URI (existing file) or empty virtual URI (new file)
+    let originalUri: vscode.Uri;
+
+    if (isNewFile) {
+      const emptyUri = vscode.Uri.parse(`${proposedEditScheme}:${encodeURIComponent(absolutePath)}?empty`);
+      this.provider.set(emptyUri, '');
+      originalUri = emptyUri;
+    } else {
+      originalUri = vscode.Uri.file(absolutePath);
+    }
+
+    // Right side: proposed content via virtual URI
+    const proposedUri = vscode.Uri.parse(
+      `${proposedEditScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
+    );
+    this.provider.set(proposedUri, proposedContent);
+
+    const pending: PendingProposedEdit = {
+      absolutePath,
+      originalContent,
+      proposedContent,
+      originalUri,
+      proposedUri,
+      isNewFile
+    };
+    this.pendingEdits.set(absolutePath, pending);
+
+    const filename = path.basename(absolutePath);
+
+    await vscode.commands.executeCommand(
+      'vscode.diff',
+      originalUri,
+      proposedUri,
+      `${filename} ↔ AI Suggestion`,
+      { preview: true }
+    );
+  }
+
+  /**
+   * Writes content to a file, creating parent directories as needed.
+   */
+  private async writeFileContent(absolutePath: string, content: string, isNewFile: boolean): Promise<void> {
+    if (isNewFile && !content) {
+      // Nothing to write for an empty new file
+      return;
+    }
+
+    try {
+      const uri = vscode.Uri.file(absolutePath);
+      // Try via VS Code workspace API first so open editors stay in sync
+      const doc = await vscode.workspace.openTextDocument(uri);
+      const edit = new vscode.WorkspaceEdit();
+      const fullRange = new vscode.Range(0, 0, doc.lineCount, 0);
+      edit.replace(uri, fullRange, content);
+      await vscode.workspace.applyEdit(edit);
+      await doc.save();
+    } catch {
+      // Fall back to direct fs write (e.g. file does not exist in workspace)
+      try {
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, content, 'utf8');
+      } catch {
+        vscode.window.showWarningMessage(`Tauren: Could not write file ${path.basename(absolutePath)}.`);
+      }
+    }
+  }
+
+  private cleanupPending(pending: PendingProposedEdit): void {
+    this.provider.delete(pending.proposedUri);
+    if (pending.isNewFile) {
+      // Also clean up the empty virtual URI used for the left side
+      const emptyUri = vscode.Uri.parse(`${proposedEditScheme}:${encodeURIComponent(pending.absolutePath)}?empty`);
+      this.provider.delete(emptyUri);
+    }
+    this.pendingEdits.delete(pending.absolutePath);
+  }
+}

--- a/src/diff/proposedEditDiff.ts
+++ b/src/diff/proposedEditDiff.ts
@@ -1,17 +1,20 @@
 import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 import * as vscode from 'vscode';
-import { proposedEditScheme, ProposedEditProvider } from './proposedEditProvider';
+import { proposedOriginalScheme, proposedEditScheme, ProposedOriginalProvider, ProposedEditProvider } from './proposedEditProvider';
 import { isRecord } from '../shared/typeGuards';
 
 /**
  * Pending diff waiting for an accept/reject decision.
+ *
+ * Left side  (originalUri) – read-only virtual showing the "before" content.
+ * Right side (proposedUri) – writable virtual showing the "after" content;
+ *                             the user may edit this before accepting.
  */
 type PendingProposedEdit = {
   absolutePath: string;
   /** The content that was on disk before the agent ran the tool. */
   originalContent: string;
-  proposedContent: string;
   originalUri: vscode.Uri;
   proposedUri: vscode.Uri;
   isNewFile: boolean;
@@ -90,23 +93,33 @@ function applyEdits(
  *  2. Call `handleToolExecution` at `tool_execution_end`.  It reads the
  *     agent-written content from disk as the "proposed" side, restores the
  *     original file so the workspace is unchanged, then opens the diff.
- *  3. The user clicks Accept (→ `acceptPendingEdit`) to apply the proposed
- *     content, or Reject (→ `rejectPendingEdit`) to leave the restored
- *     original in place.
- *
- * Bind `acceptPendingEdit` / `rejectPendingEdit` to the Accept / Reject
- * commands registered in package.json.
+ *     - Left side  (tauren-original:) – read-only, shows "before"
+ *     - Right side (tauren-proposed:) – editable virtual file, shows "after"
+ *  3. The user optionally edits the right side, then:
+ *     - Accept (→ `acceptPendingEdit`): reads the current virtual-FS content
+ *       (including any user edits) and writes it to the real file on disk.
+ *     - Reject (→ `rejectPendingEdit`): leaves the original file untouched,
+ *       closes the diff tab, and notifies the AI.
  */
+type ProposedEditDiffServiceOptions = {
+  onReject?: (absolutePath: string) => void;
+};
+
 export class ProposedEditDiffService implements vscode.Disposable {
   private pendingEdits = new Map<string, PendingProposedEdit>();
   /** Snapshots keyed by absolute path, captured before each tool execution. */
   private preExecutionSnapshots = new Map<string, PreExecutionSnapshot>();
   private nonce = 0;
+  private readonly onReject: ((absolutePath: string) => void) | undefined;
 
   public constructor(
-    private readonly provider: ProposedEditProvider,
-    private readonly getCwd: () => string | undefined
-  ) {}
+    private readonly originalProvider: ProposedOriginalProvider,
+    private readonly proposedProvider: ProposedEditProvider,
+    private readonly getCwd: () => string | undefined,
+    options: ProposedEditDiffServiceOptions = {}
+  ) {
+    this.onReject = options.onReject;
+  }
 
   public dispose(): void {
     this.pendingEdits.clear();
@@ -244,9 +257,6 @@ export class ProposedEditDiffService implements vscode.Disposable {
       return;
     }
 
-    // Use the pre-execution snapshot as the original.  If no snapshot was
-    // captured (e.g. tool_execution_start was missed), fall back to reading
-    // the current file and computing proposed from the edits the usual way.
     if (snapshot) {
       const { originalContent, isNewFile } = snapshot;
       const proposedContent = applyEdits(originalContent, edits);
@@ -262,7 +272,8 @@ export class ProposedEditDiffService implements vscode.Disposable {
     }
 
     // Fallback: no pre-execution snapshot available.
-    // Read the already-edited file content and compute original by reversing edits.
+    // Read the already-edited file and show a diff with itself on both sides
+    // (degenerate case — user can still review and accept/reject).
     let currentContent: string;
 
     try {
@@ -271,36 +282,13 @@ export class ProposedEditDiffService implements vscode.Disposable {
       return;
     }
 
-    // We cannot reliably reverse edits, so show the diff with the current
-    // (already-edited) file as "proposed" and skip restoration.
-    const nonce = ++this.nonce;
-    const proposedUri = vscode.Uri.parse(
-      `${proposedEditScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
-    );
-    this.provider.set(proposedUri, currentContent);
-
-    const pending: PendingProposedEdit = {
-      absolutePath,
-      originalContent: currentContent,
-      proposedContent: currentContent,
-      originalUri: vscode.Uri.file(absolutePath),
-      proposedUri,
-      isNewFile: false
-    };
-    this.pendingEdits.set(absolutePath, pending);
-
-    const filename = path.basename(absolutePath);
-    await vscode.commands.executeCommand(
-      'vscode.diff',
-      vscode.Uri.file(absolutePath),
-      proposedUri,
-      `${filename} ↔ AI Suggestion`,
-      { preview: true }
-    );
+    await this.openDiff(absolutePath, currentContent, currentContent, false);
   }
 
   /**
-   * Writes the accepted proposed content to disk and cleans up the diff view.
+   * Reads the current content of the writable virtual file (including any
+   * user edits), writes it to the real file on disk, closes the diff tab,
+   * and cleans up.
    */
   public async acceptPendingEdit(absolutePath: string): Promise<void> {
     const pending = this.pendingEdits.get(absolutePath);
@@ -309,30 +297,37 @@ export class ProposedEditDiffService implements vscode.Disposable {
       return;
     }
 
-    await this.writeFileContent(absolutePath, pending.proposedContent, pending.isNewFile);
+    // Read the live content from the virtual FS – the user may have edited it
+    const acceptedContent = this.proposedProvider.get(pending.proposedUri);
+    await this.writeFileContent(absolutePath, acceptedContent, pending.isNewFile);
+    await this.closeDiffEditor(pending.proposedUri);
     this.cleanupPending(pending);
   }
 
   /**
-   * Leaves the original (already-restored) file in place and cleans up the
-   * diff view.
+   * Leaves the original (already-restored) file in place, closes the diff
+   * editor, notifies the AI that the edit was rejected, and cleans up.
    */
-  public rejectPendingEdit(absolutePath: string): void {
+  public async rejectPendingEdit(absolutePath: string): Promise<void> {
     const pending = this.pendingEdits.get(absolutePath);
 
     if (!pending) {
       return;
     }
 
+    await this.closeDiffEditor(pending.proposedUri);
     this.cleanupPending(pending);
-    vscode.window.showInformationMessage(`Tauren: Proposed edit to ${path.basename(absolutePath)} was rejected.`);
+    this.onReject?.(absolutePath);
   }
 
   // ─── private ────────────────────────────────────────────────────────────────
 
   /**
    * Restores the file to `originalContent` on disk (undoing the agent's write),
-   * then opens the side-by-side diff.
+   * seeds both virtual providers, then opens the side-by-side diff.
+   *
+   * Left  (tauren-original:) – read-only, shows originalContent
+   * Right (tauren-proposed:) – writable virtual file, shows proposedContent
    */
   private async revertFileThenOpenDiff(
     absolutePath: string,
@@ -340,9 +335,13 @@ export class ProposedEditDiffService implements vscode.Disposable {
     proposedContent: string,
     isNewFile: boolean
   ): Promise<void> {
+    // Close any dirty VS Code editors for the real file BEFORE reverting,
+    // so that VS Code does not auto-save the proposed content back on top of
+    // our revert.
+    await this.closeRealFileEditors(absolutePath);
+
     // Restore the file so the workspace reflects the original state
     if (isNewFile) {
-      // Delete the newly created file so the left side of the diff is truly empty
       try {
         await fs.unlink(absolutePath);
       } catch {
@@ -352,29 +351,58 @@ export class ProposedEditDiffService implements vscode.Disposable {
       await this.writeFileContent(absolutePath, originalContent, false);
     }
 
+    await this.openDiff(absolutePath, originalContent, proposedContent, isNewFile);
+  }
+
+  /**
+   * Closes all VS Code editor tabs that have the real file open, saving or
+   * discarding changes as needed so that no dirty document can undo our revert.
+   */
+  private async closeRealFileEditors(absolutePath: string): Promise<void> {
+    const realUri = vscode.Uri.file(absolutePath);
+    const realUriStr = realUri.toString();
+
+    for (const tabGroup of vscode.window.tabGroups.all) {
+      for (const tab of tabGroup.tabs) {
+        const input = tab.input;
+        if (
+          input instanceof vscode.TabInputText &&
+          input.uri.toString() === realUriStr
+        ) {
+          // Close without saving — we are about to overwrite the file
+          await vscode.window.tabGroups.close(tab, true);
+        }
+      }
+    }
+  }
+
+  /**
+   * Seeds both virtual providers and opens the diff editor.
+   * Does NOT touch the real file on disk.
+   */
+  private async openDiff(
+    absolutePath: string,
+    originalContent: string,
+    proposedContent: string,
+    isNewFile: boolean
+  ): Promise<void> {
     const nonce = ++this.nonce;
 
-    // Left side: original file URI (existing file) or empty virtual URI (new file)
-    let originalUri: vscode.Uri;
+    // Left side: read-only virtual showing the original content
+    const originalUri = vscode.Uri.parse(
+      `${proposedOriginalScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
+    );
+    this.originalProvider.set(originalUri, originalContent);
 
-    if (isNewFile) {
-      const emptyUri = vscode.Uri.parse(`${proposedEditScheme}:${encodeURIComponent(absolutePath)}?empty`);
-      this.provider.set(emptyUri, '');
-      originalUri = emptyUri;
-    } else {
-      originalUri = vscode.Uri.file(absolutePath);
-    }
-
-    // Right side: proposed content via virtual URI
+    // Right side: writable virtual showing the proposed content
     const proposedUri = vscode.Uri.parse(
       `${proposedEditScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
     );
-    this.provider.set(proposedUri, proposedContent);
+    this.proposedProvider.set(proposedUri, proposedContent);
 
     const pending: PendingProposedEdit = {
       absolutePath,
       originalContent,
-      proposedContent,
       originalUri,
       proposedUri,
       isNewFile
@@ -394,40 +422,44 @@ export class ProposedEditDiffService implements vscode.Disposable {
 
   /**
    * Writes content to a file, creating parent directories as needed.
+   * Uses raw fs writes so VS Code's workspace/document layer does not
+   * auto-save the file as a side-effect.
    */
   private async writeFileContent(absolutePath: string, content: string, isNewFile: boolean): Promise<void> {
     if (isNewFile && !content) {
-      // Nothing to write for an empty new file
       return;
     }
 
     try {
-      const uri = vscode.Uri.file(absolutePath);
-      // Try via VS Code workspace API first so open editors stay in sync
-      const doc = await vscode.workspace.openTextDocument(uri);
-      const edit = new vscode.WorkspaceEdit();
-      const fullRange = new vscode.Range(0, 0, doc.lineCount, 0);
-      edit.replace(uri, fullRange, content);
-      await vscode.workspace.applyEdit(edit);
-      await doc.save();
+      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+      await fs.writeFile(absolutePath, content, 'utf8');
     } catch {
-      // Fall back to direct fs write (e.g. file does not exist in workspace)
-      try {
-        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-        await fs.writeFile(absolutePath, content, 'utf8');
-      } catch {
-        vscode.window.showWarningMessage(`Tauren: Could not write file ${path.basename(absolutePath)}.`);
+      vscode.window.showWarningMessage(`Tauren: Could not write file ${path.basename(absolutePath)}.`);
+    }
+  }
+
+  /**
+   * Closes any visible diff editor tab whose right-hand (proposed) URI matches
+   * `proposedUri`.
+   */
+  private async closeDiffEditor(proposedUri: vscode.Uri): Promise<void> {
+    for (const tabGroup of vscode.window.tabGroups.all) {
+      for (const tab of tabGroup.tabs) {
+        const input = tab.input;
+        if (
+          input instanceof vscode.TabInputTextDiff &&
+          input.modified.toString() === proposedUri.toString()
+        ) {
+          await vscode.window.tabGroups.close(tab, true);
+          return;
+        }
       }
     }
   }
 
   private cleanupPending(pending: PendingProposedEdit): void {
-    this.provider.delete(pending.proposedUri);
-    if (pending.isNewFile) {
-      // Also clean up the empty virtual URI used for the left side
-      const emptyUri = vscode.Uri.parse(`${proposedEditScheme}:${encodeURIComponent(pending.absolutePath)}?empty`);
-      this.provider.delete(emptyUri);
-    }
+    this.originalProvider.delete(pending.originalUri);
+    this.proposedProvider.delete(pending.proposedUri);
     this.pendingEdits.delete(pending.absolutePath);
   }
 }

--- a/src/diff/proposedEditDiff.ts
+++ b/src/diff/proposedEditDiff.ts
@@ -103,6 +103,31 @@ function applyEdits(
  */
 type ProposedEditDiffServiceOptions = {
   onReject?: (absolutePath: string) => void;
+  /**
+   * Override for opening the diff editor.  Called with the left (original) and
+   * right (proposed) URIs and the diff title.  Defaults to
+   * `vscode.commands.executeCommand('vscode.diff', ...)`.
+   */
+  openDiffEditor?: (
+    originalUri: vscode.Uri,
+    proposedUri: vscode.Uri,
+    title: string
+  ) => Promise<void>;
+  /**
+   * Override for closing the diff tab whose right-hand URI is `proposedUri`.
+   * Defaults to scanning `vscode.window.tabGroups`.
+   */
+  closeEditorByProposedUri?: (proposedUri: vscode.Uri) => Promise<void>;
+  /**
+   * Override for closing all real-file editor tabs for an absolute path.
+   * Defaults to scanning `vscode.window.tabGroups`.
+   */
+  closeRealFileEditors?: (absolutePath: string) => Promise<void>;
+  /**
+   * Override for reading the live text of a virtual document by URI string.
+   * Defaults to scanning `vscode.workspace.textDocuments`.
+   */
+  getDocumentText?: (uriString: string) => string | undefined;
 };
 
 export class ProposedEditDiffService implements vscode.Disposable {
@@ -111,6 +136,10 @@ export class ProposedEditDiffService implements vscode.Disposable {
   private preExecutionSnapshots = new Map<string, PreExecutionSnapshot>();
   private nonce = 0;
   private readonly onReject: ((absolutePath: string) => void) | undefined;
+  private readonly openDiffEditorFn: NonNullable<ProposedEditDiffServiceOptions['openDiffEditor']>;
+  private readonly closeEditorByProposedUriFn: NonNullable<ProposedEditDiffServiceOptions['closeEditorByProposedUri']>;
+  private readonly closeRealFileEditorsFn: NonNullable<ProposedEditDiffServiceOptions['closeRealFileEditors']>;
+  private readonly getDocumentTextFn: NonNullable<ProposedEditDiffServiceOptions['getDocumentText']>;
 
   public constructor(
     private readonly originalProvider: ProposedOriginalProvider,
@@ -119,6 +148,15 @@ export class ProposedEditDiffService implements vscode.Disposable {
     options: ProposedEditDiffServiceOptions = {}
   ) {
     this.onReject = options.onReject;
+    this.openDiffEditorFn = options.openDiffEditor ?? (async (origUri, propUri, title) => {
+      await vscode.commands.executeCommand('vscode.diff', origUri, propUri, title, { preview: true });
+    });
+    this.closeEditorByProposedUriFn = options.closeEditorByProposedUri ?? ((proposedUri) => this.closeDiffEditor(proposedUri));
+    this.closeRealFileEditorsFn = options.closeRealFileEditors ?? ((absolutePath) => this.closeRealFileEditors(absolutePath));
+    this.getDocumentTextFn = options.getDocumentText ?? ((uriString) => {
+      const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() === uriString);
+      return doc?.getText();
+    });
   }
 
   public dispose(): void {
@@ -297,10 +335,12 @@ export class ProposedEditDiffService implements vscode.Disposable {
       return;
     }
 
-    // Read the live content from the virtual FS – the user may have edited it
-    const acceptedContent = this.proposedProvider.get(pending.proposedUri);
+    // Prefer the open TextDocument buffer so unsaved user edits are included.
+    // Fall back to the provider's in-memory store if the document is not open.
+    const liveText = this.getDocumentTextFn(pending.proposedUri.toString());
+    const acceptedContent = liveText ?? this.proposedProvider.get(pending.proposedUri);
     await this.writeFileContent(absolutePath, acceptedContent, pending.isNewFile);
-    await this.closeDiffEditor(pending.proposedUri);
+    await this.closeEditorByProposedUriFn(pending.proposedUri);
     this.cleanupPending(pending);
   }
 
@@ -338,7 +378,7 @@ export class ProposedEditDiffService implements vscode.Disposable {
     // Close any dirty VS Code editors for the real file BEFORE reverting,
     // so that VS Code does not auto-save the proposed content back on top of
     // our revert.
-    await this.closeRealFileEditors(absolutePath);
+    await this.closeRealFileEditorsFn(absolutePath);
 
     // Restore the file so the workspace reflects the original state
     if (isNewFile) {
@@ -410,14 +450,7 @@ export class ProposedEditDiffService implements vscode.Disposable {
     this.pendingEdits.set(absolutePath, pending);
 
     const filename = path.basename(absolutePath);
-
-    await vscode.commands.executeCommand(
-      'vscode.diff',
-      originalUri,
-      proposedUri,
-      `${filename} ↔ AI Suggestion`,
-      { preview: true }
-    );
+    await this.openDiffEditorFn(originalUri, proposedUri, `${filename} ↔ AI Suggestion`);
   }
 
   /**

--- a/src/diff/proposedEditDiff.ts
+++ b/src/diff/proposedEditDiff.ts
@@ -1,8 +1,8 @@
 import * as path from 'node:path';
 import { promises as fs } from 'node:fs';
 import * as vscode from 'vscode';
-import { proposedOriginalScheme, proposedEditScheme, ProposedOriginalProvider, ProposedEditProvider } from './proposedEditProvider';
-import { isRecord } from '../shared/typeGuards';
+import { proposedOriginalScheme as originalScheme, proposedEditScheme, ProposedOriginalProvider, ProposedEditProvider } from './proposedEditProvider';
+import { isRecord, getRecordString } from '../shared/typeGuards';
 
 /**
  * Pending diff waiting for an accept/reject decision.
@@ -11,7 +11,7 @@ import { isRecord } from '../shared/typeGuards';
  * Right side (proposedUri) – writable virtual showing the "after" content;
  *                             the user may edit this before accepting.
  */
-type PendingProposedEdit = {
+type PendingEdit = {
   absolutePath: string;
   /** The content that was on disk before the agent ran the tool. */
   originalContent: string;
@@ -29,11 +29,6 @@ type PreExecutionSnapshot = {
   originalContent: string;
   isNewFile: boolean;
 };
-
-function getRecordString(record: Record<string, unknown>, key: string): string | undefined {
-  const value = record[key];
-  return typeof value === 'string' ? value : undefined;
-}
 
 /**
  * Resolves the absolute path for a tool-call file argument, given the session
@@ -131,7 +126,7 @@ type ProposedEditDiffServiceOptions = {
 };
 
 export class ProposedEditDiffService implements vscode.Disposable {
-  private pendingEdits = new Map<string, PendingProposedEdit>();
+  private pendingEdits = new Map<string, PendingEdit>();
   /** Snapshots keyed by absolute path, captured before each tool execution. */
   private preExecutionSnapshots = new Map<string, PreExecutionSnapshot>();
   private nonce = 0;
@@ -430,7 +425,7 @@ export class ProposedEditDiffService implements vscode.Disposable {
 
     // Left side: read-only virtual showing the original content
     const originalUri = vscode.Uri.parse(
-      `${proposedOriginalScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
+      `${originalScheme}:${encodeURIComponent(absolutePath)}?${nonce}`
     );
     this.originalProvider.set(originalUri, originalContent);
 
@@ -440,7 +435,7 @@ export class ProposedEditDiffService implements vscode.Disposable {
     );
     this.proposedProvider.set(proposedUri, proposedContent);
 
-    const pending: PendingProposedEdit = {
+    const pending: PendingEdit = {
       absolutePath,
       originalContent,
       originalUri,
@@ -490,7 +485,7 @@ export class ProposedEditDiffService implements vscode.Disposable {
     }
   }
 
-  private cleanupPending(pending: PendingProposedEdit): void {
+  private cleanupPending(pending: PendingEdit): void {
     this.originalProvider.delete(pending.originalUri);
     this.proposedProvider.delete(pending.proposedUri);
     this.pendingEdits.delete(pending.absolutePath);

--- a/src/diff/proposedEditProvider.ts
+++ b/src/diff/proposedEditProvider.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode';
+
+/**
+ * URI scheme used for the "after" side of proposed-edit diff views.
+ * Virtual URIs have the form: `tauren-proposed:<absoluteFilePath>?<nonce>`
+ */
+export const proposedEditScheme = 'tauren-proposed';
+
+/**
+ * Provides read-only virtual document content for the "after" side of a
+ * proposed-edit diff.  Content is stored in memory and cleaned up when the
+ * associated text document is closed or when `delete` is called explicitly.
+ */
+export class ProposedEditProvider implements vscode.TextDocumentContentProvider, vscode.Disposable {
+  private readonly contents = new Map<string, string>();
+  private readonly onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  private readonly disposables: vscode.Disposable[] = [];
+
+  public readonly onDidChange = this.onDidChangeEmitter.event;
+
+  public constructor() {
+    this.disposables.push(
+      vscode.workspace.onDidCloseTextDocument((document) => {
+        if (document.uri.scheme === proposedEditScheme) {
+          this.contents.delete(document.uri.toString());
+        }
+      })
+    );
+  }
+
+  public dispose(): void {
+    this.onDidChangeEmitter.dispose();
+    for (const disposable of this.disposables) {
+      disposable.dispose();
+    }
+    this.contents.clear();
+  }
+
+  /** Store content for a URI, firing a change event so VS Code re-reads it. */
+  public set(uri: vscode.Uri, content: string): void {
+    this.contents.set(uri.toString(), content);
+    this.onDidChangeEmitter.fire(uri);
+  }
+
+  /** Remove stored content. */
+  public delete(uri: vscode.Uri): void {
+    this.contents.delete(uri.toString());
+  }
+
+  public provideTextDocumentContent(uri: vscode.Uri): string {
+    return this.contents.get(uri.toString()) ?? '';
+  }
+}

--- a/src/diff/proposedEditProvider.ts
+++ b/src/diff/proposedEditProvider.ts
@@ -1,48 +1,38 @@
 import * as vscode from 'vscode';
 
 /**
- * URI scheme used for the "after" side of proposed-edit diff views.
- * Virtual URIs have the form: `tauren-proposed:<absoluteFilePath>?<nonce>`
+ * URI scheme for the read-only "before" (original) side of proposed-edit diffs.
+ */
+export const proposedOriginalScheme = 'tauren-original';
+
+/**
+ * URI scheme for the writable "after" (proposed) side of proposed-edit diffs.
+ * Uses a FileSystemProvider so VS Code treats the document as editable.
  */
 export const proposedEditScheme = 'tauren-proposed';
 
+// ─── Read-only original provider (left side) ────────────────────────────────
+
 /**
- * Provides read-only virtual document content for the "after" side of a
- * proposed-edit diff.  Content is stored in memory and cleaned up when the
- * associated text document is closed or when `delete` is called explicitly.
+ * Provides read-only virtual document content for the "before" side of a
+ * proposed-edit diff.  Content is stored in memory.
  */
-export class ProposedEditProvider implements vscode.TextDocumentContentProvider, vscode.Disposable {
+export class ProposedOriginalProvider implements vscode.TextDocumentContentProvider, vscode.Disposable {
   private readonly contents = new Map<string, string>();
   private readonly onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
-  private readonly disposables: vscode.Disposable[] = [];
 
   public readonly onDidChange = this.onDidChangeEmitter.event;
 
-  public constructor() {
-    this.disposables.push(
-      vscode.workspace.onDidCloseTextDocument((document) => {
-        if (document.uri.scheme === proposedEditScheme) {
-          this.contents.delete(document.uri.toString());
-        }
-      })
-    );
-  }
-
   public dispose(): void {
     this.onDidChangeEmitter.dispose();
-    for (const disposable of this.disposables) {
-      disposable.dispose();
-    }
     this.contents.clear();
   }
 
-  /** Store content for a URI, firing a change event so VS Code re-reads it. */
   public set(uri: vscode.Uri, content: string): void {
     this.contents.set(uri.toString(), content);
     this.onDidChangeEmitter.fire(uri);
   }
 
-  /** Remove stored content. */
   public delete(uri: vscode.Uri): void {
     this.contents.delete(uri.toString());
   }
@@ -50,4 +40,83 @@ export class ProposedEditProvider implements vscode.TextDocumentContentProvider,
   public provideTextDocumentContent(uri: vscode.Uri): string {
     return this.contents.get(uri.toString()) ?? '';
   }
+}
+
+// ─── Writable proposed-edit filesystem provider (right side) ─────────────────
+
+/**
+ * A `FileSystemProvider` that backs virtual proposed-edit documents with
+ * in-memory storage.  Because it implements the full `FileSystemProvider`
+ * interface, VS Code allows the user to edit the document in the diff editor.
+ */
+export class ProposedEditProvider implements vscode.FileSystemProvider, vscode.Disposable {
+  private readonly files = new Map<string, Uint8Array>();
+  private readonly onDidChangeFileEmitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+
+  public readonly onDidChangeFile = this.onDidChangeFileEmitter.event;
+
+  public dispose(): void {
+    this.onDidChangeFileEmitter.dispose();
+    this.files.clear();
+  }
+
+  /** Seed content for a given virtual URI. */
+  public set(uri: vscode.Uri, content: string): void {
+    this.files.set(uri.toString(), Buffer.from(content, 'utf8'));
+    this.onDidChangeFileEmitter.fire([{ type: vscode.FileChangeType.Changed, uri }]);
+  }
+
+  /** Get the current content of a virtual file (includes any user edits). */
+  public get(uri: vscode.Uri): string {
+    const data = this.files.get(uri.toString());
+    return data ? Buffer.from(data).toString('utf8') : '';
+  }
+
+  /** Remove stored content. */
+  public delete(uri: vscode.Uri): void {
+    if (this.files.has(uri.toString())) {
+      this.files.delete(uri.toString());
+      this.onDidChangeFileEmitter.fire([{ type: vscode.FileChangeType.Deleted, uri }]);
+    }
+  }
+
+  // ─── FileSystemProvider interface ──────────────────────────────────────────
+
+  public watch(): vscode.Disposable {
+    return new vscode.Disposable(() => {});
+  }
+
+  public stat(uri: vscode.Uri): vscode.FileStat {
+    const data = this.files.get(uri.toString());
+    if (!data) {
+      throw vscode.FileSystemError.FileNotFound(uri);
+    }
+    return {
+      type: vscode.FileType.File,
+      ctime: Date.now(),
+      mtime: Date.now(),
+      size: data.byteLength
+    };
+  }
+
+  public readDirectory(): [string, vscode.FileType][] {
+    return [];
+  }
+
+  public createDirectory(): void {}
+
+  public readFile(uri: vscode.Uri): Uint8Array {
+    const data = this.files.get(uri.toString());
+    if (!data) {
+      throw vscode.FileSystemError.FileNotFound(uri);
+    }
+    return data;
+  }
+
+  public writeFile(uri: vscode.Uri, content: Uint8Array): void {
+    this.files.set(uri.toString(), content);
+    this.onDidChangeFileEmitter.fire([{ type: vscode.FileChangeType.Changed, uri }]);
+  }
+
+  public rename(): void {}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,20 @@
 import * as vscode from 'vscode';
 import { taurenChatViewType, TaurenChatViewProvider } from './taurenChatViewProvider';
+import { ProposedEditProvider, proposedEditScheme } from './diff/proposedEditProvider';
+import { ProposedEditDiffService } from './diff/proposedEditDiff';
 
 export function activate(context: vscode.ExtensionContext): void {
+  const proposedEditProvider = new ProposedEditProvider();
+  const proposedEditDiffService = new ProposedEditDiffService(
+    proposedEditProvider,
+    () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+  );
+
+  context.subscriptions.push(
+    proposedEditProvider,
+    vscode.workspace.registerTextDocumentContentProvider(proposedEditScheme, proposedEditProvider)
+  );
+
   const provider = new TaurenChatViewProvider(
     context.extensionUri,
     undefined,
@@ -10,7 +23,8 @@ export function activate(context: vscode.ExtensionContext): void {
     undefined,
     context.extensionMode === vscode.ExtensionMode.Development,
     context.storageUri ?? context.globalStorageUri,
-    context.globalStorageUri
+    context.globalStorageUri,
+    proposedEditDiffService
   );
 
   context.subscriptions.push(
@@ -56,7 +70,21 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('tauren.addContext', () => provider.addContext()),
     vscode.commands.registerCommand('tauren.sendSelectionToComposer', () => provider.sendSelectionToComposer()),
     vscode.commands.registerCommand('tauren.traceOrigin', () => provider.traceOrigin()),
-    vscode.commands.registerCommand('tauren.showDiagnostics', () => provider.showDiagnostics())
+    vscode.commands.registerCommand('tauren.showDiagnostics', () => provider.showDiagnostics()),
+    vscode.commands.registerCommand('tauren.acceptProposedEdit', () => {
+      const uri = vscode.window.activeTextEditor?.document.uri;
+      if (uri?.scheme === proposedEditScheme) {
+        const absolutePath = decodeURIComponent(uri.path);
+        void proposedEditDiffService.acceptPendingEdit(absolutePath);
+      }
+    }),
+    vscode.commands.registerCommand('tauren.rejectProposedEdit', () => {
+      const uri = vscode.window.activeTextEditor?.document.uri;
+      if (uri?.scheme === proposedEditScheme) {
+        const absolutePath = decodeURIComponent(uri.path);
+        proposedEditDiffService.rejectPendingEdit(absolutePath);
+      }
+    })
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,18 +1,23 @@
 import * as vscode from 'vscode';
 import { taurenChatViewType, TaurenChatViewProvider } from './taurenChatViewProvider';
-import { ProposedEditProvider, proposedEditScheme } from './diff/proposedEditProvider';
+import { ProposedOriginalProvider, ProposedEditProvider, proposedOriginalScheme, proposedEditScheme } from './diff/proposedEditProvider';
 import { ProposedEditDiffService } from './diff/proposedEditDiff';
 
 export function activate(context: vscode.ExtensionContext): void {
+  const proposedOriginalProvider = new ProposedOriginalProvider();
   const proposedEditProvider = new ProposedEditProvider();
   const proposedEditDiffService = new ProposedEditDiffService(
+    proposedOriginalProvider,
     proposedEditProvider,
-    () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+    () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+    { onReject: (absolutePath) => provider.notifyProposedEditRejected(absolutePath) }
   );
 
   context.subscriptions.push(
+    proposedOriginalProvider,
     proposedEditProvider,
-    vscode.workspace.registerTextDocumentContentProvider(proposedEditScheme, proposedEditProvider)
+    vscode.workspace.registerTextDocumentContentProvider(proposedOriginalScheme, proposedOriginalProvider),
+    vscode.workspace.registerFileSystemProvider(proposedEditScheme, proposedEditProvider, { isCaseSensitive: true })
   );
 
   const provider = new TaurenChatViewProvider(
@@ -82,7 +87,7 @@ export function activate(context: vscode.ExtensionContext): void {
       const uri = vscode.window.activeTextEditor?.document.uri;
       if (uri?.scheme === proposedEditScheme) {
         const absolutePath = decodeURIComponent(uri.path);
-        proposedEditDiffService.rejectPendingEdit(absolutePath);
+        void proposedEditDiffService.rejectPendingEdit(absolutePath);
       }
     })
   );

--- a/src/taurenChatController.ts
+++ b/src/taurenChatController.ts
@@ -146,7 +146,13 @@ export class TaurenChatController {
       refreshSessionDiffStats: () => void this.refreshSessionDiffStats(),
       refreshContextUsage: () => void this.refreshContextUsage({ silent: true }),
       refreshModelCatalog: () => void this.refreshSessionMeta({ startClient: true, force: true }),
-      addToolExecution: (event) => this.sessionDiffController.addToolExecution(event),
+      captureBeforeToolExecution: (event) => {
+        void this.options.captureBeforeProposedEditDiff?.(event);
+      },
+      addToolExecution: (event) => {
+        this.sessionDiffController.addToolExecution(event);
+        void this.options.showProposedEditDiff?.(event);
+      },
       armQueuedReadyScriptRun: () => this.armQueuedReadyScriptRun(),
       runReadyScriptAfterAgentEnd: () => {
         if (this.readyScriptState.consumeCurrentRun()) {

--- a/src/taurenChatViewProvider.ts
+++ b/src/taurenChatViewProvider.ts
@@ -893,6 +893,14 @@ export class TaurenChatViewProvider implements vscode.WebviewViewProvider, vscod
     );
   }
 
+  public notifyProposedEditRejected(absolutePath: string): void {
+    const filename = path.basename(absolutePath);
+    void this.controller.handleWebviewMessage({
+      type: 'submit',
+      text: `The proposed edit to \`${filename}\` was rejected by the user.`
+    });
+  }
+
   public async showDiagnostics(): Promise<void> {
     const document = await vscode.workspace.openTextDocument({
       content: this.perf.formatDiagnostics(),

--- a/src/taurenChatViewProvider.ts
+++ b/src/taurenChatViewProvider.ts
@@ -17,6 +17,7 @@ import type { CustomUiHostMessage } from './extensionUi/customUiHost';
 import type { ExtensionEditorHostMessage, ExtensionPromptHostMessage, ExtensionUi } from './extensionUi/types';
 import { createSessionDiffStatsFileWatcher, readSessionDiffSnapshot, writeSessionDiffSnapshot } from './diff/sessionDiffStorage';
 import { SessionDiffViewer } from './diff/sessionDiffViewer';
+import type { ProposedEditDiffService } from './diff/proposedEditDiff';
 import { ShikiCodeRenderer } from './highlighting/shikiCodeRenderer';
 import { TaurenSessionManager } from './sessions/taurenSessionManager';
 import type { PiPromptImageAttachment } from './taurenChatController';
@@ -170,7 +171,8 @@ export class TaurenChatViewProvider implements vscode.WebviewViewProvider, vscod
     private readonly workspaceCwdProvider: () => string | undefined = () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
     private readonly devRenderInstrumentation = false,
     private readonly sessionMetadataStorageUri?: vscode.Uri,
-    private readonly voiceStorageUri?: vscode.Uri
+    private readonly voiceStorageUri?: vscode.Uri,
+    private readonly proposedEditDiffService?: ProposedEditDiffService
   ) {
     this.cachedQuietStartup = this.workspaceState?.get<boolean>(quietStartupStorageKey);
 
@@ -268,6 +270,12 @@ export class TaurenChatViewProvider implements vscode.WebviewViewProvider, vscod
         displayName,
         readSessionDiffSnapshot(this.workspaceState, sessionPath)
       ),
+      captureBeforeProposedEditDiff: this.proposedEditDiffService
+        ? (input) => this.proposedEditDiffService!.captureBeforeToolExecution(input)
+        : undefined,
+      showProposedEditDiff: this.proposedEditDiffService
+        ? (input) => this.proposedEditDiffService!.handleToolExecution(input)
+        : undefined,
       voiceController: this.voiceController
     });
 

--- a/src/test/suite/proposedEditDiff.test.ts
+++ b/src/test/suite/proposedEditDiff.test.ts
@@ -1,0 +1,387 @@
+import * as assert from 'node:assert';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { ProposedEditDiffService } from '../../diff/proposedEditDiff';
+import { ProposedOriginalProvider, ProposedEditProvider, proposedOriginalScheme, proposedEditScheme } from '../../diff/proposedEditProvider';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+type DiffOpenCall = {
+  originalUri: vscode.Uri;
+  proposedUri: vscode.Uri;
+  title: string;
+};
+
+/**
+ * Creates a `ProposedEditDiffService` with all VS Code side-effects stubbed
+ * out.  Returns the service, the two providers (so tests can inspect virtual
+ * document content), and a list of recorded `openDiffEditor` calls.
+ */
+function makeService(
+  cwd: string | undefined,
+  onReject?: (absolutePath: string) => void
+): {
+  service: ProposedEditDiffService;
+  originalProvider: ProposedOriginalProvider;
+  proposedProvider: ProposedEditProvider;
+  diffOpenCalls: DiffOpenCall[];
+  closedProposedUris: vscode.Uri[];
+  /** Simulate a user edit in the virtual proposed document. */
+  setDocumentText: (uri: vscode.Uri, text: string) => void;
+} {
+  const originalProvider = new ProposedOriginalProvider();
+  const proposedProvider = new ProposedEditProvider();
+  const diffOpenCalls: DiffOpenCall[] = [];
+  const closedProposedUris: vscode.Uri[] = [];
+  const documentTexts = new Map<string, string>();
+
+  const service = new ProposedEditDiffService(
+    originalProvider,
+    proposedProvider,
+    () => cwd,
+    {
+      onReject,
+      openDiffEditor: async (originalUri, proposedUri, title) => {
+        diffOpenCalls.push({ originalUri, proposedUri, title });
+      },
+      closeEditorByProposedUri: async (proposedUri) => {
+        closedProposedUris.push(proposedUri);
+      },
+      closeRealFileEditors: async () => {
+        // no-op in tests
+      },
+      getDocumentText: (uriString) => documentTexts.get(uriString)
+    }
+  );
+
+  return {
+    service,
+    originalProvider,
+    proposedProvider,
+    diffOpenCalls,
+    closedProposedUris,
+    setDocumentText: (uri, text) => documentTexts.set(uri.toString(), text)
+  };
+}
+
+/** Read a file from disk and return its content, or undefined if it does not exist. */
+async function readFileOrUndefined(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+suite('ProposedEditDiffService', () => {
+  let cwd: string;
+
+  setup(async () => {
+    cwd = await fs.mkdtemp(path.join(os.tmpdir(), 'tauren-proposed-edit-'));
+  });
+
+  teardown(async () => {
+    await fs.rm(cwd, { recursive: true, force: true });
+  });
+
+  // ── 1. Diff view opens; left = original, right = proposed ──────────────────
+
+  test('opens a diff view with original content on the left and proposed content on the right for a write tool', async () => {
+    const filePath = path.join(cwd, 'hello.ts');
+    await fs.writeFile(filePath, 'const greeting = "hello";\n', 'utf8');
+
+    const { service, originalProvider, proposedProvider, diffOpenCalls } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'const greeting = "hi";\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'const greeting = "hi";\n' }
+    });
+
+    assert.strictEqual(diffOpenCalls.length, 1, 'Expected exactly one diff editor to open');
+
+    const { originalUri, proposedUri, title } = diffOpenCalls[0];
+
+    assert.strictEqual(originalUri.scheme, proposedOriginalScheme, 'Left URI must use the tauren-original scheme');
+    assert.strictEqual(proposedUri.scheme, proposedEditScheme, 'Right URI must use the tauren-proposed scheme');
+    assert.ok(title.includes('hello.ts'), 'Diff title must include the filename');
+
+    const originalContent = originalProvider.provideTextDocumentContent(originalUri);
+    assert.strictEqual(originalContent, 'const greeting = "hello";\n', 'Left side must show original file content');
+
+    const proposedContent = proposedProvider.get(proposedUri);
+    assert.strictEqual(proposedContent, 'const greeting = "hi";\n', 'Right side must show the AI-proposed content');
+  });
+
+  test('opens a diff view with original content on the left and proposed content on the right for an edit tool', async () => {
+    const filePath = path.join(cwd, 'example.ts');
+    await fs.writeFile(filePath, 'const x = 1;\n', 'utf8');
+
+    const { service, originalProvider, proposedProvider, diffOpenCalls } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'edit',
+      args: { path: filePath, edits: [{ oldText: 'const x = 1;\n', newText: 'const x = 42;\n' }] }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'edit',
+      args: { path: filePath, edits: [{ oldText: 'const x = 1;\n', newText: 'const x = 42;\n' }] }
+    });
+
+    assert.strictEqual(diffOpenCalls.length, 1, 'Expected exactly one diff editor to open');
+
+    const { originalUri, proposedUri } = diffOpenCalls[0];
+    assert.strictEqual(originalProvider.provideTextDocumentContent(originalUri), 'const x = 1;\n');
+    assert.strictEqual(proposedProvider.get(proposedUri), 'const x = 42;\n');
+  });
+
+  // ── 2. File on disk is NOT modified while the diff is open ─────────────────
+
+  test('file on disk is restored to original content when the diff view opens (write tool)', async () => {
+    const filePath = path.join(cwd, 'target.ts');
+    await fs.writeFile(filePath, 'original content\n', 'utf8');
+
+    const { service } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'proposed content\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'proposed content\n' }
+    });
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(
+      diskContent,
+      'original content\n',
+      'Disk must show original content while the diff is pending'
+    );
+  });
+
+  test('new file does not exist on disk while the diff is open', async () => {
+    const filePath = path.join(cwd, 'brand-new.ts');
+    // File does NOT exist on disk before the tool runs
+
+    const { service } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'brand new content\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'brand new content\n' }
+    });
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(diskContent, undefined, 'New file must not exist on disk while the diff is pending');
+  });
+
+  // ── 3. Reject does not write to disk ───────────────────────────────────────
+
+  test('rejecting a write proposal leaves the original file unchanged on disk', async () => {
+    const filePath = path.join(cwd, 'keep.ts');
+    await fs.writeFile(filePath, 'original\n', 'utf8');
+
+    const { service, diffOpenCalls } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'proposed\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'proposed\n' }
+    });
+
+    assert.strictEqual(diffOpenCalls.length, 1);
+    await service.rejectPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(diskContent, 'original\n', 'Disk must be unchanged after rejecting');
+  });
+
+  test('rejecting a write proposal for a new file leaves the file absent from disk', async () => {
+    const filePath = path.join(cwd, 'new-rejected.ts');
+
+    const { service } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'new content\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'new content\n' }
+    });
+
+    await service.rejectPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(diskContent, undefined, 'New file must not be created on disk after rejecting');
+  });
+
+  test('rejecting an edit proposal calls the onReject callback', async () => {
+    const filePath = path.join(cwd, 'callback.ts');
+    await fs.writeFile(filePath, 'const v = 1;\n', 'utf8');
+
+    const rejectedPaths: string[] = [];
+    const { service } = makeService(cwd, (p) => rejectedPaths.push(p));
+
+    await service.captureBeforeToolExecution({
+      toolName: 'edit',
+      args: { path: filePath, edits: [{ oldText: 'const v = 1;\n', newText: 'const v = 2;\n' }] }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'edit',
+      args: { path: filePath, edits: [{ oldText: 'const v = 1;\n', newText: 'const v = 2;\n' }] }
+    });
+
+    await service.rejectPendingEdit(filePath);
+
+    assert.deepStrictEqual(rejectedPaths, [filePath], 'onReject must be called with the file path');
+  });
+
+  // ── 4. Accept writes the proposed content to disk ──────────────────────────
+
+  test('accepting a write proposal writes the proposed content to disk', async () => {
+    const filePath = path.join(cwd, 'accept.ts');
+    await fs.writeFile(filePath, 'old content\n', 'utf8');
+
+    const { service } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'new content\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'new content\n' }
+    });
+
+    await service.acceptPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(diskContent, 'new content\n', 'Disk must contain the proposed content after accepting');
+  });
+
+  test('accepting an edit proposal writes the result of applied edits to disk', async () => {
+    const filePath = path.join(cwd, 'edited.ts');
+    await fs.writeFile(filePath, 'const a = 1;\n', 'utf8');
+
+    const { service } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'edit',
+      args: { path: filePath, edits: [{ oldText: 'const a = 1;\n', newText: 'const a = 99;\n' }] }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'edit',
+      args: { path: filePath, edits: [{ oldText: 'const a = 1;\n', newText: 'const a = 99;\n' }] }
+    });
+
+    await service.acceptPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(diskContent, 'const a = 99;\n', 'Disk must contain the edited content after accepting');
+  });
+
+  test('accepting a new-file proposal creates the file on disk', async () => {
+    const filePath = path.join(cwd, 'created.ts');
+
+    const { service } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'export const created = true;\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'export const created = true;\n' }
+    });
+
+    await service.acceptPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(diskContent, 'export const created = true;\n', 'New file must be created on disk after accepting');
+  });
+
+  // ── 5. Accept uses the live document text (user edits before accepting) ─────
+
+  test('if the user edits the proposed virtual document before accepting, the edited content is written to disk', async () => {
+    const filePath = path.join(cwd, 'user-edits.ts');
+    await fs.writeFile(filePath, 'const original = true;\n', 'utf8');
+
+    const { service, diffOpenCalls, setDocumentText } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'const aiProposed = true;\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'const aiProposed = true;\n' }
+    });
+
+    assert.strictEqual(diffOpenCalls.length, 1, 'Expected diff to open before user edits');
+
+    // Simulate the user typing into the right-hand (proposed) virtual document
+    const proposedUri = diffOpenCalls[0].proposedUri;
+    setDocumentText(proposedUri, 'const userModified = true;\n');
+
+    await service.acceptPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.strictEqual(
+      diskContent,
+      'const userModified = true;\n',
+      'Disk must contain the user-modified content, not the original AI proposal'
+    );
+  });
+
+  test('if the user edits the proposed document before accepting, the AI proposal is NOT written to disk', async () => {
+    const filePath = path.join(cwd, 'override-check.ts');
+    await fs.writeFile(filePath, 'const v = 0;\n', 'utf8');
+
+    const { service, diffOpenCalls, setDocumentText } = makeService(cwd);
+
+    await service.captureBeforeToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'const v = 1;\n' }
+    });
+
+    await service.handleToolExecution({
+      toolName: 'write',
+      args: { path: filePath, content: 'const v = 1;\n' }
+    });
+
+    const proposedUri = diffOpenCalls[0].proposedUri;
+    setDocumentText(proposedUri, 'const v = 999;\n');
+
+    await service.acceptPendingEdit(filePath);
+
+    const diskContent = await readFileOrUndefined(filePath);
+    assert.notStrictEqual(diskContent, 'const v = 1;\n', 'AI proposal must not be written when user edited the document');
+    assert.strictEqual(diskContent, 'const v = 999;\n', 'User-edited content must be on disk');
+  });
+});


### PR DESCRIPTION
This PR is a feature proposal. This PR proposes that each file edit is shown as a full-screen side-by-side diff. The user can accept, modify or reject each edit in the full-screen diff view.

The advantages are:
 -  multi-line edits are easier to read
 - edits are easier to check against their surrounding context
 - the user has agency over accepting or rejecting each edit that Pi suggests

Please let me know what you think of this proposal. Please let me know if you think:
 - few users would like this feature, so this should be scrapped,
 - some users would like this feature, so this should be a toggleable setting,
 - most users would like this feature, so this should be applied to all edits
 
 The PR applies this to all edits, but I'm happy to go back and make this a toggleable feature. This PR is intended to be squash-merged.

Thanks for making such a great extension!