### PR TITLE
Add sourcemap and TypeScript debugging support for webview

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,13 @@
         "${workspaceFolder}/out/**/*.js"
       ],
       "debugWebviews": true,
+      "rendererDebugOptions": {
+        "sourceMaps": true
+      },
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
       "preLaunchTask": "npm: compile"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,12 @@
       "script": "compile",
       "group": "build",
       "problemMatcher": "$tsc",
-      "label": "npm: compile"
+      "label": "npm: compile",
+      "options": {
+        "env": {
+          "TAUREN_WEBVIEW_SOURCEMAP": "1"
+        }
+      }
     }
   ]
 }

--- a/docs/development/webview.md
+++ b/docs/development/webview.md
@@ -38,6 +38,18 @@ resources/webview/chat.js
 
 Generated first-party webview assets belong under `resources/webview`. Vendored browser-only libraries live under `resources/vendor`.
 
+## Debugging
+
+Start the **Run Extension** debug configuration to build the webview with an inline source map and debug the TypeScript files under `src/webview` directly.
+
+For rebuilds while the Extension Host is running, enable source maps when starting the watcher:
+
+```sh
+TAUREN_WEBVIEW_SOURCEMAP=1 npm run watch
+```
+
+Normal builds omit the source map unless `TAUREN_WEBVIEW_SOURCEMAP` is set to `1`.
+
 ## Rendering expectations
 
 The webview should feel VS Code-native:

--- a/package.json
+++ b/package.json
@@ -735,7 +735,7 @@
     "clean": "node -e \"require('fs').rmSync('out', { recursive: true, force: true })\"",
     "vscode:prepublish": "npm run compile",
     "compile": "npm run clean && npm run compile:webview && npm run compile:sdk && tsc -p ./",
-    "compile:webview": "esbuild src/webview/main.ts --bundle --format=iife --target=es2022 --outfile=resources/webview/chat.js",
+    "compile:webview": "node scripts/build-webview.js",
     "sync:vendor": "node scripts/sync-vendor-deps.js",
     "update:pi-sdk": "node scripts/update-pi-sdk.js",
     "verify:pi-sdk": "node scripts/verify-pi-sdk-peer-runtime.js",

--- a/scripts/build-webview.js
+++ b/scripts/build-webview.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// Builds the webview bundle (src/webview/main.ts -> resources/webview/chat.js).
+// Set TAUREN_WEBVIEW_SOURCEMAP=1 to embed an inline source map for debugging
+// webview code in DevTools / the webview debugger.
+
+const esbuild = require('esbuild');
+
+esbuild.build({
+  entryPoints: ['src/webview/main.ts'],
+  bundle: true,
+  format: 'iife',
+  target: 'es2022',
+  outfile: 'resources/webview/chat.js',
+  sourcemap: process.env.TAUREN_WEBVIEW_SOURCEMAP === '1' ? 'inline' : false
+}).catch(() => {
+  process.exit(1);
+});

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -64,6 +64,7 @@ async function main() {
     format: 'iife',
     target: 'es2022',
     outfile: 'resources/webview/chat.js',
+    sourcemap: process.env.TAUREN_WEBVIEW_SOURCEMAP === '1' ? 'inline' : false,
     logLevel: 'info'
   });
   await esbuildContext.watch();


### PR DESCRIPTION
Enables TypeScript source map generation for the webview's `chat.js`. This allows us to debug the TypeScript code directly. This is guarded by `TAUREN_WEBVIEW_SOURCEMAP=1` env. var., so normal VSCE invocation will not generate the source map.

Also, added additional VSCode workspace configurations to make the webview debugging on the TypeScript sources to work straight away out of the box.